### PR TITLE
fix: create daemon log directory before opening log file

### DIFF
--- a/mcproc/src/common/config/mod.rs
+++ b/mcproc/src/common/config/mod.rs
@@ -179,6 +179,11 @@ impl Config {
         std::fs::create_dir_all(&self.paths.data_dir)?;
         std::fs::create_dir_all(&self.paths.log_dir)?;
 
+        // Ensure the daemon log file's parent directory exists
+        if let Some(parent) = self.paths.daemon_log_file.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
         // Ensure runtime directory exists
         if let Some(parent) = self.paths.socket_path.parent() {
             std::fs::create_dir_all(parent)?;


### PR DESCRIPTION
Fixes #37

## Problem

`mcproc daemon start` fails with:

```
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

before the daemon is ever spawned.

## Root cause

In `start_daemon()`, the CLI opens the daemon log file with `OpenOptions::create(true)`:

```rust
let log_file = std::fs::OpenOptions::new()
    .create(true)
    ...
    .open(config.daemon_log_file())?;
```

`create(true)` creates the file but not any missing parent directories. The daemon log lives at `$XDG_STATE_HOME/mcproc/log/mcprocd.log`, and `Config::ensure_directories()` creates `data_dir`, the runtime `log_dir`, the socket parent, and the config dir — but never the daemon log file's parent (`$XDG_STATE_HOME/mcproc/log/`). If that directory doesn't already exist, the open fails with `NotFound`.

## Fix

Create the daemon log file's parent directory in `ensure_directories()`.

## Verification

- Reproduced the error on a clean state dir, confirmed the fix resolves it (`daemon start` succeeds, `mcproc ps` connects, log file is created).
- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --all-targets`, `cargo test` all pass.
