### PR TITLE
fix: source code review — 37 bug and vulnerability fixes (Rounds 1-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "mcproc"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "prost",
  "prost-types",

--- a/mcp-rs/src/protocol.rs
+++ b/mcp-rs/src/protocol.rs
@@ -34,6 +34,19 @@ pub trait McpHandler: Send + Sync {
     async fn handle(&self, params: Option<Value>) -> Result<Value>;
 }
 
+fn invalid_request_response(id: JsonRpcId) -> JsonRpcMessage {
+    JsonRpcMessage::Response(JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        result: None,
+        error: Some(JsonRpcError {
+            code: error_codes::INVALID_REQUEST,
+            message: "Invalid Request".to_string(),
+            data: None,
+        }),
+        id,
+    })
+}
+
 impl Protocol {
     pub fn new(name: String, version: String) -> Self {
         Self {
@@ -90,6 +103,12 @@ impl Protocol {
                 None
             }
             JsonRpcMessage::Batch(batch) => {
+                if batch.is_empty() {
+                    return (
+                        Some(invalid_request_response(JsonRpcId::Null)),
+                        queued_sender.take_all().await,
+                    );
+                }
                 let mut responses = Vec::new();
                 for msg in batch {
                     let (resp, _) = Box::pin(self.handle_message(msg)).await;
@@ -134,6 +153,9 @@ impl Protocol {
                 None
             }
             JsonRpcMessage::Batch(batch) => {
+                if batch.is_empty() {
+                    return Some(invalid_request_response(JsonRpcId::Null));
+                }
                 let mut responses = Vec::new();
                 for msg in batch {
                     if let Some(resp) = Box::pin(self.handle_message_realtime(msg)).await {
@@ -167,6 +189,13 @@ impl Protocol {
         req: JsonRpcRequest,
         notification_sender: Arc<dyn crate::notification::NotificationSender>,
     ) -> JsonRpcResponse {
+        if req.jsonrpc != "2.0" {
+            return match invalid_request_response(req.id) {
+                JsonRpcMessage::Response(response) => response,
+                _ => unreachable!(),
+            };
+        }
+
         let result = match req.method.parse::<McpMethod>().unwrap() {
             McpMethod::Initialize => self.handle_initialize(req.params).await,
             McpMethod::ToolsList => self.handle_tools_list(req.params).await,
@@ -352,6 +381,57 @@ impl Protocol {
                 message: error.to_string(),
                 data: None,
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_invalid_request(message: Option<JsonRpcMessage>) {
+        match message {
+            Some(JsonRpcMessage::Response(response)) => {
+                assert_eq!(response.id, JsonRpcId::Null);
+                assert_eq!(response.error.unwrap().code, error_codes::INVALID_REQUEST);
+            }
+            other => panic!("expected invalid-request response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_batch_returns_invalid_request() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+
+        let (queued, _) = protocol
+            .handle_message(JsonRpcMessage::Batch(Vec::new()))
+            .await;
+        let realtime = protocol
+            .handle_message_realtime(JsonRpcMessage::Batch(Vec::new()))
+            .await;
+
+        assert_invalid_request(queued);
+        assert_invalid_request(realtime);
+    }
+
+    #[tokio::test]
+    async fn non_2_0_request_returns_invalid_request() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+        let request = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "1.0".to_string(),
+            method: "initialize".to_string(),
+            params: None,
+            id: JsonRpcId::Number(7),
+        });
+
+        let response = protocol.handle_message_realtime(request).await;
+
+        match response {
+            Some(JsonRpcMessage::Response(response)) => {
+                assert_eq!(response.id, JsonRpcId::Number(7));
+                assert_eq!(response.error.unwrap().code, error_codes::INVALID_REQUEST);
+            }
+            other => panic!("expected invalid-request response, got {other:?}"),
         }
     }
 }

--- a/mcp-rs/src/server.rs
+++ b/mcp-rs/src/server.rs
@@ -13,11 +13,11 @@ use tracing::{debug, info};
 
 /// Real-time notification sender that sends notifications immediately
 struct RealtimeNotificationSender {
-    tx: mpsc::Sender<JsonRpcNotification>,
+    tx: mpsc::UnboundedSender<JsonRpcNotification>,
 }
 
 impl RealtimeNotificationSender {
-    fn new(tx: mpsc::Sender<JsonRpcNotification>) -> Self {
+    fn new(tx: mpsc::UnboundedSender<JsonRpcNotification>) -> Self {
         Self { tx }
     }
 }
@@ -31,7 +31,7 @@ impl NotificationSender for RealtimeNotificationSender {
             params: Some(serde_json::to_value(notification)?),
         };
 
-        self.tx.send(notif).await.map_err(|_| {
+        self.tx.send(notif).map_err(|_| {
             crate::error::Error::Internal("Failed to send notification".to_string())
         })?;
         Ok(())
@@ -44,7 +44,7 @@ impl NotificationSender for RealtimeNotificationSender {
             params: Some(serde_json::to_value(notification)?),
         };
 
-        self.tx.send(notif).await.map_err(|_| {
+        self.tx.send(notif).map_err(|_| {
             crate::error::Error::Internal("Failed to send notification".to_string())
         })?;
         Ok(())
@@ -57,7 +57,7 @@ impl NotificationSender for RealtimeNotificationSender {
             params,
         };
 
-        self.tx.send(notif).await.map_err(|_| {
+        self.tx.send(notif).map_err(|_| {
             crate::error::Error::Internal("Failed to send notification".to_string())
         })?;
         Ok(())
@@ -87,7 +87,8 @@ impl Server {
         self.transport.start().await?;
 
         // Create notification channel
-        let (notification_tx, mut notification_rx) = mpsc::channel::<JsonRpcNotification>(100);
+        let (notification_tx, mut notification_rx) =
+            mpsc::unbounded_channel::<JsonRpcNotification>();
 
         // Create real-time notification sender
         let realtime_sender = Arc::new(RealtimeNotificationSender::new(notification_tx.clone()));
@@ -165,5 +166,84 @@ impl ServerBuilder {
         }
 
         Ok(Server::new(protocol, transport))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{JsonRpcId, JsonRpcRequest, MessageLevel, ToolInfo};
+    use serde_json::json;
+    use std::collections::VecDeque;
+
+    struct MockTransport {
+        incoming: VecDeque<JsonRpcMessage>,
+    }
+
+    #[async_trait]
+    impl Transport for MockTransport {
+        async fn start(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send(&mut self, _message: JsonRpcMessage) -> Result<()> {
+            Ok(())
+        }
+
+        async fn receive(&mut self) -> Result<Option<JsonRpcMessage>> {
+            Ok(self.incoming.pop_front())
+        }
+
+        async fn close(&mut self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    struct NoisyTool;
+
+    #[async_trait]
+    impl ToolHandler for NoisyTool {
+        fn tool_info(&self) -> ToolInfo {
+            ToolInfo {
+                name: "noisy".to_string(),
+                description: "sends many notifications".to_string(),
+                input_schema: json!({"type": "object"}),
+            }
+        }
+
+        async fn handle(
+            &self,
+            _params: Option<Value>,
+            context: crate::notification::ToolContext,
+        ) -> Result<Value> {
+            for index in 0..150 {
+                context
+                    .send_log(MessageLevel::Info, format!("notification {index}"))
+                    .await?;
+            }
+            Ok(json!({"done": true}))
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_call_with_more_than_channel_capacity_does_not_deadlock() {
+        let transport = MockTransport {
+            incoming: VecDeque::from([JsonRpcMessage::Request(JsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                method: "tools/call".to_string(),
+                params: Some(json!({"name": "noisy", "arguments": {}})),
+                id: JsonRpcId::Number(1),
+            })]),
+        };
+        let mut server = ServerBuilder::new("test", "1")
+            .add_tool(Arc::new(NoisyTool))
+            .build(Box::new(transport))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), server.start())
+            .await
+            .expect("server deadlocked while tool sent notifications")
+            .unwrap();
     }
 }

--- a/mcp-rs/src/transport/stdio.rs
+++ b/mcp-rs/src/transport/stdio.rs
@@ -2,8 +2,36 @@ use crate::error::Result;
 use crate::transport::Transport;
 use crate::types::JsonRpcMessage;
 use async_trait::async_trait;
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
+
+fn parse_input_line(line: &str) -> std::result::Result<JsonRpcMessage, Box<JsonRpcMessage>> {
+    serde_json::from_str(line).map_err(|_| {
+        Box::new(JsonRpcMessage::Response(crate::types::JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            result: None,
+            error: Some(crate::types::JsonRpcError {
+                code: crate::types::error_codes::PARSE_ERROR,
+                message: "Parse error".to_string(),
+                data: None,
+            }),
+            id: crate::types::JsonRpcId::Null,
+        }))
+    })
+}
+
+async fn write_message(
+    stdout: &Arc<Mutex<tokio::io::Stdout>>,
+    message: &JsonRpcMessage,
+) -> Result<()> {
+    let json = serde_json::to_string(message)?;
+    let mut stdout = stdout.lock().await;
+    stdout.write_all(json.as_bytes()).await?;
+    stdout.write_all(b"\n").await?;
+    stdout.flush().await?;
+    Ok(())
+}
 
 /// Stdio transport for MCP communication
 pub struct StdioTransport {
@@ -12,6 +40,7 @@ pub struct StdioTransport {
     tx: Option<mpsc::Sender<JsonRpcMessage>>,
     rx: mpsc::Receiver<JsonRpcMessage>,
     shutdown_tx: mpsc::Sender<()>,
+    stdout: Arc<Mutex<tokio::io::Stdout>>,
 }
 
 impl StdioTransport {
@@ -23,6 +52,7 @@ impl StdioTransport {
             tx: Some(tx),
             rx,
             shutdown_tx,
+            stdout: Arc::new(Mutex::new(tokio::io::stdout())),
         }
     }
 }
@@ -44,6 +74,7 @@ impl Transport for StdioTransport {
 
         let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
         self.shutdown_tx = shutdown_tx;
+        let stdout = self.stdout.clone();
 
         // Spawn stdin reader
         tokio::spawn(async move {
@@ -57,9 +88,16 @@ impl Transport for StdioTransport {
                     line = lines.next_line() => {
                         match line {
                             Ok(Some(line)) => {
-                                if let Ok(message) = serde_json::from_str::<JsonRpcMessage>(&line) {
-                                    if tx.send(message).await.is_err() {
-                                        break;
+                                match parse_input_line(&line) {
+                                    Ok(message) => {
+                                        if tx.send(message).await.is_err() {
+                                            break;
+                                        }
+                                    }
+                                    Err(response) => {
+                                        if write_message(&stdout, &response).await.is_err() {
+                                            break;
+                                        }
                                     }
                                 }
                             }
@@ -76,12 +114,7 @@ impl Transport for StdioTransport {
     }
 
     async fn send(&mut self, message: JsonRpcMessage) -> Result<()> {
-        let json = serde_json::to_string(&message)?;
-        let mut stdout = tokio::io::stdout();
-        stdout.write_all(json.as_bytes()).await?;
-        stdout.write_all(b"\n").await?;
-        stdout.flush().await?;
-        Ok(())
+        write_message(&self.stdout, &message).await
     }
 
     async fn receive(&mut self) -> Result<Option<JsonRpcMessage>> {
@@ -91,5 +124,22 @@ impl Transport for StdioTransport {
     async fn close(&mut self) -> Result<()> {
         let _ = self.shutdown_tx.send(()).await;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_input_line;
+    use crate::types::{error_codes, JsonRpcId, JsonRpcMessage};
+
+    #[test]
+    fn invalid_json_produces_parse_error_response() {
+        match *parse_input_line("{not json").unwrap_err() {
+            JsonRpcMessage::Response(response) => {
+                assert_eq!(response.id, JsonRpcId::Null);
+                assert_eq!(response.error.unwrap().code, error_codes::PARSE_ERROR);
+            }
+            other => panic!("expected parse-error response, got {other:?}"),
+        }
     }
 }

--- a/mcproc/src/cli/commands/daemon.rs
+++ b/mcproc/src/cli/commands/daemon.rs
@@ -3,6 +3,34 @@
 use crate::common::config::Config;
 use clap::{Parser, Subcommand};
 use std::time::Duration;
+use sysinfo::{Pid, System};
+
+fn command_identifies_mcproc(name: &str, command_line: &str) -> bool {
+    name.contains("mcproc") || command_line.contains("mcproc")
+}
+
+fn pid_is_mcproc_daemon(pid: i32) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+    if nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_err() {
+        return false;
+    }
+
+    let system = System::new_all();
+    let Some(process) = system.process(Pid::from_u32(pid as u32)) else {
+        // Preserve the existing liveness behavior if process metadata is unavailable.
+        return true;
+    };
+    let name = process.name().to_string_lossy();
+    let command_line = process
+        .cmd()
+        .iter()
+        .map(|part| part.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ");
+    command_identifies_mcproc(&name, &command_line)
+}
 
 #[derive(Parser)]
 pub struct DaemonCommand {
@@ -72,6 +100,13 @@ impl DaemonCommand {
                     .trim()
                     .parse::<i32>()?;
 
+                if !pid_is_mcproc_daemon(pid) {
+                    return Err(format!(
+                        "Refusing to signal PID {pid}: process is not an mcproc daemon"
+                    )
+                    .into());
+                }
+
                 // Send SIGTERM
                 nix::sys::signal::kill(
                     nix::unistd::Pid::from_raw(pid),
@@ -103,6 +138,12 @@ impl DaemonCommand {
                 }
 
                 println!("Warning: daemon did not stop gracefully, sending SIGKILL");
+                if !pid_is_mcproc_daemon(pid) {
+                    return Err(format!(
+                        "Refusing to signal PID {pid}: process is not an mcproc daemon"
+                    )
+                    .into());
+                }
                 nix::sys::signal::kill(
                     nix::unistd::Pid::from_raw(pid),
                     nix::sys::signal::Signal::SIGKILL,
@@ -124,6 +165,13 @@ impl DaemonCommand {
                     let pid = std::fs::read_to_string(&config.paths.pid_file)?
                         .trim()
                         .parse::<i32>()?;
+
+                    if !pid_is_mcproc_daemon(pid) {
+                        return Err(format!(
+                            "Refusing to signal PID {pid}: process is not an mcproc daemon"
+                        )
+                        .into());
+                    }
 
                     nix::sys::signal::kill(
                         nix::unistd::Pid::from_raw(pid),
@@ -160,6 +208,12 @@ impl DaemonCommand {
                     // If daemon didn't stop gracefully, force kill it
                     if !stopped {
                         println!("Daemon did not stop gracefully, sending SIGKILL...");
+                        if !pid_is_mcproc_daemon(pid) {
+                            return Err(format!(
+                                "Refusing to signal PID {pid}: process is not an mcproc daemon"
+                            )
+                            .into());
+                        }
                         nix::sys::signal::kill(
                             nix::unistd::Pid::from_raw(pid),
                             nix::sys::signal::Signal::SIGKILL,
@@ -276,7 +330,7 @@ fn is_daemon_running_with_details(config: &Config) -> (bool, Option<i32>) {
             // Now verify with PID file
             if let Ok(pid_str) = std::fs::read_to_string(&config.paths.pid_file) {
                 if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                    return (true, Some(pid));
+                    return (pid_is_mcproc_daemon(pid), Some(pid));
                 }
             }
             // Socket exists but no valid PID file - suspicious state
@@ -325,6 +379,10 @@ fn is_daemon_running_with_details(config: &Config) -> (bool, Option<i32>) {
                             }
                         }
                     }
+                }
+
+                if !pid_is_mcproc_daemon(pid) {
+                    return (false, Some(pid));
                 }
 
                 // Process exists and is not a zombie but socket is not working
@@ -396,8 +454,7 @@ fn start_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
     let log_file = std::fs::OpenOptions::new()
         .create(true)
-        .write(true)
-        .truncate(true)
+        .append(true)
         .open(config.daemon_log_file())?;
 
     let mut cmd = std::process::Command::new(&mcproc_path);
@@ -428,7 +485,9 @@ fn start_daemon() -> Result<(), Box<dyn std::error::Error>> {
                 config.daemon.startup_timeout_ms / config.daemon.stop_check_interval_ms;
             for i in 0..max_wait_iterations {
                 std::thread::sleep(Duration::from_millis(config.daemon.stop_check_interval_ms));
-                if config.paths.pid_file.exists() {
+                if config.paths.pid_file.exists()
+                    && std::os::unix::net::UnixStream::connect(&config.paths.socket_path).is_ok()
+                {
                     println!("Daemon started successfully");
                     return Ok(());
                 }
@@ -462,8 +521,30 @@ fn start_daemon() -> Result<(), Box<dyn std::error::Error>> {
                     );
                 }
             }
-            Err("Daemon failed to start (PID file not created)".into())
+            Err("Daemon failed to start (PID file or socket not ready)".into())
         }
         Err(e) => Err(format!("Failed to spawn mcprocd: {}", e).into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{command_identifies_mcproc, pid_is_mcproc_daemon};
+
+    #[test]
+    fn command_identity_requires_mcproc() {
+        assert!(command_identifies_mcproc("mcproc", "mcproc --daemon"));
+        assert!(!command_identifies_mcproc("sleep", "sleep 5"));
+    }
+
+    #[test]
+    fn sleep_process_is_not_an_mcproc_daemon() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        assert!(!pid_is_mcproc_daemon(child.id() as i32));
+        child.kill().unwrap();
+        child.wait().unwrap();
     }
 }

--- a/mcproc/src/cli/commands/daemon.rs
+++ b/mcproc/src/cli/commands/daemon.rs
@@ -5,8 +5,14 @@ use clap::{Parser, Subcommand};
 use std::time::Duration;
 use sysinfo::{Pid, System};
 
-fn command_identifies_mcproc(name: &str, command_line: &str) -> bool {
-    name.contains("mcproc") || command_line.contains("mcproc")
+fn command_identifies_mcproc_daemon(name: &str, command: &[String]) -> bool {
+    let executable_is_mcproc = name == "mcproc"
+        || command
+            .first()
+            .and_then(|argv0| std::path::Path::new(argv0).file_name())
+            .and_then(|basename| basename.to_str())
+            == Some("mcproc");
+    executable_is_mcproc && command.iter().any(|argument| argument == "--daemon")
 }
 
 fn pid_is_mcproc_daemon(pid: i32) -> bool {
@@ -23,13 +29,13 @@ fn pid_is_mcproc_daemon(pid: i32) -> bool {
         return true;
     };
     let name = process.name().to_string_lossy();
-    let command_line = process
+    let command = process
         .cmd()
         .iter()
         .map(|part| part.to_string_lossy())
-        .collect::<Vec<_>>()
-        .join(" ");
-    command_identifies_mcproc(&name, &command_line)
+        .map(|part| part.into_owned())
+        .collect::<Vec<_>>();
+    command_identifies_mcproc_daemon(&name, &command)
 }
 
 #[derive(Parser)]
@@ -330,7 +336,7 @@ fn is_daemon_running_with_details(config: &Config) -> (bool, Option<i32>) {
             // Now verify with PID file
             if let Ok(pid_str) = std::fs::read_to_string(&config.paths.pid_file) {
                 if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                    return (pid_is_mcproc_daemon(pid), Some(pid));
+                    return (true, Some(pid));
                 }
             }
             // Socket exists but no valid PID file - suspicious state
@@ -452,10 +458,22 @@ fn start_daemon() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("Consider running 'mcproc daemon stop' first to clean up");
     }
 
-    let log_file = std::fs::OpenOptions::new()
+    let mut log_file = std::fs::OpenOptions::new()
         .create(true)
+        .read(true)
         .append(true)
         .open(config.daemon_log_file())?;
+
+    use std::io::{Read, Seek, Write};
+    let file_len = log_file.metadata()?.len();
+    if file_len > 0 {
+        log_file.seek(std::io::SeekFrom::End(-1))?;
+        let mut last_byte = [0];
+        log_file.read_exact(&mut last_byte)?;
+        if last_byte[0] != b'\n' {
+            log_file.write_all(b"\n")?;
+        }
+    }
 
     let mut cmd = std::process::Command::new(&mcproc_path);
     cmd.arg("--daemon")
@@ -529,12 +547,33 @@ fn start_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_identifies_mcproc, pid_is_mcproc_daemon};
+    use super::{
+        command_identifies_mcproc_daemon, is_daemon_running_with_details, pid_is_mcproc_daemon,
+    };
+    use crate::common::config::Config;
 
     #[test]
     fn command_identity_requires_mcproc() {
-        assert!(command_identifies_mcproc("mcproc", "mcproc --daemon"));
-        assert!(!command_identifies_mcproc("sleep", "sleep 5"));
+        assert!(command_identifies_mcproc_daemon(
+            "mcproc",
+            &["mcproc".into(), "--daemon".into()]
+        ));
+        assert!(command_identifies_mcproc_daemon(
+            "other",
+            &["/usr/local/bin/mcproc".into(), "--daemon".into()]
+        ));
+        assert!(!command_identifies_mcproc_daemon(
+            "mcproc",
+            &["mcproc".into(), "start".into(), "x".into()]
+        ));
+        assert!(!command_identifies_mcproc_daemon(
+            "vim",
+            &["vim".into(), "mcproc/notes.md".into()]
+        ));
+        assert!(!command_identifies_mcproc_daemon(
+            "sleep",
+            &["sleep".into(), "5".into()]
+        ));
     }
 
     #[test]
@@ -546,5 +585,28 @@ mod tests {
         assert!(!pid_is_mcproc_daemon(child.id() as i32));
         child.kill().unwrap();
         child.wait().unwrap();
+    }
+
+    #[test]
+    fn connectable_socket_is_running_even_when_pid_is_not_mcproc() {
+        let root = std::path::PathBuf::from("/tmp").join(format!("mcp-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let mut config = Config::default();
+        config.paths.socket_path = root.join("mcprocd.sock");
+        config.paths.pid_file = root.join("mcprocd.pid");
+        let listener = std::os::unix::net::UnixListener::bind(&config.paths.socket_path).unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        let pid = child.id() as i32;
+        std::fs::write(&config.paths.pid_file, pid.to_string()).unwrap();
+
+        assert_eq!(is_daemon_running_with_details(&config), (true, Some(pid)));
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        drop(listener);
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/mcproc/src/cli/commands/mcp/tools/restart.rs
+++ b/mcproc/src/cli/commands/mcp/tools/restart.rs
@@ -8,6 +8,7 @@ use mcp_rs::{Error as McpError, Result as McpResult, ToolHandler, ToolInfo};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use strip_ansi_escapes::strip;
+use tonic::Request;
 
 pub struct RestartTool {
     client: DaemonClient,
@@ -65,12 +66,22 @@ impl ToolHandler for RestartTool {
 
         let project = resolve_mcp_project_name(params.project)?;
 
-        let request = proto::RestartProcessRequest {
+        let wait_timeout = params.wait_timeout;
+        let grpc_request = proto::RestartProcessRequest {
             name: params.name.clone(),
             project,
             wait_for_log: params.wait_for_log,
-            wait_timeout: params.wait_timeout,
+            wait_timeout,
         };
+
+        let config =
+            crate::common::config::Config::load().map_err(|e| McpError::Internal(e.to_string()))?;
+        let mut request = Request::new(grpc_request);
+        request.set_timeout(crate::cli::utils::restart_deadline(
+            config.process.restart.process_stop_timeout_ms,
+            wait_timeout,
+            config.process.startup.default_wait_timeout_secs,
+        ));
 
         let mut client = self.client.clone();
         match client.inner().restart_process(request).await {

--- a/mcproc/src/cli/commands/mcp/tools/start.rs
+++ b/mcproc/src/cli/commands/mcp/tools/start.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use mcp_rs::{Error as McpError, Result as McpResult, ToolHandler, ToolInfo};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::time::Duration;
 use strip_ansi_escapes::strip;
 use tonic::Request;
 
@@ -143,7 +142,7 @@ impl ToolHandler for StartTool {
         };
 
         // Set timeout to wait_timeout + 5 seconds to allow for process startup
-        let timeout = Duration::from_secs((wait_timeout_value.unwrap_or(30) + 5) as u64);
+        let timeout = crate::cli::utils::start_deadline(wait_timeout_value.unwrap_or(30));
         let mut request = Request::new(grpc_request);
         request.set_timeout(timeout);
 
@@ -172,18 +171,11 @@ impl ToolHandler for StartTool {
                 // Collect all streaming responses
                 let mut log_count = 0;
 
-                eprintln!("DEBUG: MCP start - waiting for gRPC stream messages...");
-                while let Some(msg) = stream.message().await.map_err(|e| {
-                    eprintln!("DEBUG: MCP start - stream error: {}", e);
-                    McpError::Internal(e.to_string())
-                })? {
-                    eprintln!(
-                        "DEBUG: MCP start - received message type: {:?}",
-                        msg.response.as_ref().map(|r| match r {
-                            proto::start_process_response::Response::LogEntry(_) => "LogEntry",
-                            proto::start_process_response::Response::Process(_) => "Process",
-                        })
-                    );
+                while let Some(msg) = stream
+                    .message()
+                    .await
+                    .map_err(|e| McpError::Internal(e.to_string()))?
+                {
                     match msg.response {
                         Some(proto::start_process_response::Response::LogEntry(entry)) => {
                             // Send log entry as notification
@@ -223,11 +215,6 @@ impl ToolHandler for StartTool {
                         None => {}
                     }
                 }
-
-                eprintln!(
-                    "DEBUG: MCP start - stream ended, process_info available: {}",
-                    process_info.is_some()
-                );
 
                 let process = process_info
                     .ok_or_else(|| McpError::Internal("No process info returned".to_string()))?;
@@ -271,12 +258,6 @@ impl ToolHandler for StartTool {
                 }
 
                 // Always include log context from ProcessInfo (strip ANSI codes)
-                eprintln!(
-                    "DEBUG: MCP start - process: {}, log_context: {} lines, matched_line: {}",
-                    process.name,
-                    process.log_context.len(),
-                    process.matched_line.is_some()
-                );
                 if !process.log_context.is_empty() {
                     let cleaned_context: Vec<String> = process
                         .log_context

--- a/mcproc/src/cli/commands/mcp/tools/stop.rs
+++ b/mcproc/src/cli/commands/mcp/tools/stop.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use mcp_rs::{Error as McpError, Result as McpResult, ToolHandler, ToolInfo};
 use serde::Deserialize;
 use serde_json::{json, Value};
+use tonic::Request;
 
 pub struct StopTool {
     client: DaemonClient,
@@ -53,11 +54,18 @@ impl ToolHandler for StopTool {
 
         let project = resolve_mcp_project_name(params.project)?;
 
-        let request = proto::StopProcessRequest {
+        let grpc_request = proto::StopProcessRequest {
             name: params.name,
             force: None,
             project,
         };
+
+        let config =
+            crate::common::config::Config::load().map_err(|e| McpError::Internal(e.to_string()))?;
+        let mut request = Request::new(grpc_request);
+        request.set_timeout(crate::cli::utils::stop_deadline(
+            config.process.restart.process_stop_timeout_ms,
+        ));
 
         let mut client = self.client.clone();
         let response = client

--- a/mcproc/src/cli/commands/ps.rs
+++ b/mcproc/src/cli/commands/ps.rs
@@ -35,7 +35,7 @@ struct ProcessRow {
 impl PsCommand {
     pub async fn execute(self, mut client: DaemonClient) -> Result<(), Box<dyn std::error::Error>> {
         let request = ListProcessesRequest {
-            status_filter: None, // TODO: Parse status filter
+            status_filter: self.status.as_deref().map(parse_status).transpose()?,
             project_filter: None,
         };
 
@@ -69,11 +69,30 @@ impl PsCommand {
     }
 }
 
+fn parse_status(status: &str) -> Result<i32, String> {
+    let status = match status.to_ascii_lowercase().as_str() {
+        "unknown" => proto::ProcessStatus::Unknown,
+        "starting" => proto::ProcessStatus::Starting,
+        "running" => proto::ProcessStatus::Running,
+        "stopping" => proto::ProcessStatus::Stopping,
+        "stopped" => proto::ProcessStatus::Stopped,
+        "failed" => proto::ProcessStatus::Failed,
+        _ => return Err(format!("Invalid process status: {status}")),
+    };
+    Ok(status as i32)
+}
+
 fn truncate(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    if s.chars().count() <= max_len {
         s.to_string()
+    } else if max_len <= 3 {
+        ".".repeat(max_len)
     } else {
-        format!("{}...", &s[..max_len - 3])
+        let cutoff = s
+            .char_indices()
+            .nth(max_len - 3)
+            .map_or(s.len(), |(index, _)| index);
+        format!("{}...", &s[..cutoff])
     }
 }
 
@@ -86,5 +105,18 @@ fn format_ports(ports: &[u32]) -> String {
             .map(|p| p.to_string())
             .collect::<Vec<_>>()
             .join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate;
+
+    #[test]
+    fn truncate_handles_multibyte_characters() {
+        let truncated = truncate("日本語のとても長いコマンドライン文字列テスト", 10);
+
+        assert_eq!(truncated.chars().count(), 10);
+        assert!(truncated.ends_with("..."));
     }
 }

--- a/mcproc/src/cli/commands/restart.rs
+++ b/mcproc/src/cli/commands/restart.rs
@@ -3,7 +3,6 @@ use crate::client::DaemonClient;
 use clap::Args;
 use colored::*;
 use proto::RestartProcessRequest;
-use std::time::Duration;
 use tonic::Request;
 
 #[derive(Debug, Args)]
@@ -31,9 +30,10 @@ impl RestartCommand {
         let config = crate::common::config::Config::load()?;
         // Set timeout based on config: process_stop_timeout + grpc_request_buffer
         // Restart needs more time: stop + start
-        let timeout = Duration::from_millis(
-            (config.process.restart.process_stop_timeout_ms * 2)
-                + config.api.grpc_request_buffer_secs * 1000,
+        let timeout = crate::cli::utils::restart_deadline(
+            config.process.restart.process_stop_timeout_ms,
+            None,
+            config.process.startup.default_wait_timeout_secs,
         );
         let mut request = Request::new(grpc_request);
         request.set_timeout(timeout);

--- a/mcproc/src/cli/commands/start.rs
+++ b/mcproc/src/cli/commands/start.rs
@@ -5,7 +5,6 @@ use crate::common::validation::validate_process_name;
 use clap::Args;
 use colored::*;
 use proto::StartProcessRequest;
-use std::time::Duration;
 use tonic::Request;
 
 #[derive(Debug, Args)]
@@ -81,7 +80,7 @@ impl StartCommand {
         };
 
         // Set timeout to wait_timeout + 5 seconds to allow for process startup and pattern matching
-        let timeout = Duration::from_secs((self.wait_timeout + 5) as u64);
+        let timeout = crate::cli::utils::start_deadline(self.wait_timeout);
         let mut request = Request::new(grpc_request);
         request.set_timeout(timeout);
 

--- a/mcproc/src/cli/commands/stop.rs
+++ b/mcproc/src/cli/commands/stop.rs
@@ -3,7 +3,6 @@ use crate::client::DaemonClient;
 use clap::Args;
 use colored::*;
 use proto::StopProcessRequest;
-use std::time::Duration;
 use tonic::Request;
 
 #[derive(Debug, Args)]
@@ -31,10 +30,8 @@ impl StopCommand {
         // Load config to get timeout settings
         let config = crate::common::config::Config::load()?;
         // Set timeout based on config: process_stop_timeout + grpc_request_buffer
-        let timeout = Duration::from_millis(
-            config.process.restart.process_stop_timeout_ms
-                + config.api.grpc_request_buffer_secs * 1000,
-        );
+        let timeout =
+            crate::cli::utils::stop_deadline(config.process.restart.process_stop_timeout_ms);
         let mut request = Request::new(grpc_request);
         request.set_timeout(timeout);
 

--- a/mcproc/src/cli/utils.rs
+++ b/mcproc/src/cli/utils.rs
@@ -1,6 +1,27 @@
 //! Utility functions for mcproc
 
 use crate::common::validation::validate_project_name;
+use std::time::Duration;
+
+pub(crate) fn start_deadline(wait_timeout: u32) -> Duration {
+    Duration::from_secs(u64::from(wait_timeout).saturating_add(5))
+}
+
+pub(crate) fn stop_deadline(process_stop_timeout_ms: u64) -> Duration {
+    Duration::from_millis(process_stop_timeout_ms.saturating_add(15_000))
+}
+
+pub(crate) fn restart_deadline(
+    process_stop_timeout_ms: u64,
+    wait_timeout: Option<u32>,
+    default_wait_timeout_secs: u32,
+) -> Duration {
+    Duration::from_millis(process_stop_timeout_ms)
+        .saturating_add(Duration::from_secs(u64::from(
+            wait_timeout.unwrap_or(default_wait_timeout_secs),
+        )))
+        .saturating_add(Duration::from_secs(20))
+}
 
 /// Get the project name from environment variable
 /// Returns None if not set
@@ -62,4 +83,32 @@ pub fn resolve_mcp_project_name(params_project: Option<String>) -> Result<String
     Err(mcp_rs::Error::InvalidParams(
         "Unable to determine project name. Please specify --project, set MCPROC_DEFAULT_PROJECT, or run from a valid project directory".to_string()
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{restart_deadline, start_deadline, stop_deadline};
+    use std::time::Duration;
+
+    #[test]
+    fn start_deadline_handles_maximum_u32() {
+        assert_eq!(
+            start_deadline(u32::MAX),
+            Duration::from_secs(u64::from(u32::MAX) + 5)
+        );
+    }
+
+    #[test]
+    fn stop_deadline_covers_force_fallback_and_cleanup() {
+        assert_eq!(stop_deadline(30_000), Duration::from_secs(45));
+    }
+
+    #[test]
+    fn restart_deadline_covers_stop_wait_and_cleanup() {
+        assert_eq!(
+            restart_deadline(30_000, Some(60), 30),
+            Duration::from_secs(110)
+        );
+        assert_eq!(restart_deadline(30_000, None, 30), Duration::from_secs(80));
+    }
 }

--- a/mcproc/src/client/mod.rs
+++ b/mcproc/src/client/mod.rs
@@ -33,6 +33,8 @@ impl DaemonClient {
         if !daemon_running {
             eprintln!("mcprocd daemon is not running. Starting it automatically...");
 
+            config.ensure_directories()?;
+
             // Start daemon in background (use current binary with --daemon flag)
             let mcproc_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mcproc"));
 

--- a/mcproc/src/common/config/mod.rs
+++ b/mcproc/src/common/config/mod.rs
@@ -176,13 +176,35 @@ impl Config {
     }
 
     pub fn ensure_directories(&self) -> std::io::Result<()> {
+        let log_dir_existed = self.paths.log_dir.exists();
+        let socket_parent_existed = self
+            .paths
+            .socket_path
+            .parent()
+            .map(|parent| parent.exists())
+            .unwrap_or(false);
+
         std::fs::create_dir_all(&self.paths.data_dir)?;
         std::fs::create_dir_all(&self.paths.log_dir)?;
 
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&self.paths.log_dir, std::fs::Permissions::from_mode(0o700))?;
+            if log_dir_existed {
+                let mode = std::fs::metadata(&self.paths.log_dir)?.permissions().mode();
+                if mode & 0o077 != 0 {
+                    tracing::warn!(
+                        path = %self.paths.log_dir.display(),
+                        mode = format_args!("{:#o}", mode & 0o777),
+                        "Existing log directory has group or other permissions"
+                    );
+                }
+            } else {
+                std::fs::set_permissions(
+                    &self.paths.log_dir,
+                    std::fs::Permissions::from_mode(0o700),
+                )?;
+            }
         }
 
         // Ensure runtime directory exists
@@ -191,7 +213,18 @@ impl Config {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+                if socket_parent_existed {
+                    let mode = std::fs::metadata(parent)?.permissions().mode();
+                    if mode & 0o077 != 0 {
+                        tracing::warn!(
+                            path = %parent.display(),
+                            mode = format_args!("{:#o}", mode & 0o777),
+                            "Existing runtime directory has group or other permissions"
+                        );
+                    }
+                } else {
+                    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+                }
             }
         }
 
@@ -251,7 +284,31 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn ensure_directories_sets_private_runtime_and_log_permissions() {
+    fn ensure_directories_sets_private_permissions_for_new_directories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (config, root) = test_config();
+
+        config.ensure_directories().unwrap();
+
+        let runtime_mode = std::fs::metadata(config.paths.socket_path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let log_mode = std::fs::metadata(&config.paths.log_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(runtime_mode, 0o700);
+        assert_eq!(log_mode, 0o700);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_directories_preserves_existing_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
         let (config, root) = test_config();
@@ -280,8 +337,8 @@ mod tests {
             .permissions()
             .mode()
             & 0o777;
-        assert_eq!(runtime_mode, 0o700);
-        assert_eq!(log_mode, 0o700);
+        assert_eq!(runtime_mode, 0o755);
+        assert_eq!(log_mode, 0o755);
         std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/mcproc/src/common/config/mod.rs
+++ b/mcproc/src/common/config/mod.rs
@@ -179,8 +179,23 @@ impl Config {
         std::fs::create_dir_all(&self.paths.data_dir)?;
         std::fs::create_dir_all(&self.paths.log_dir)?;
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.paths.log_dir, std::fs::Permissions::from_mode(0o700))?;
+        }
+
         // Ensure runtime directory exists
         if let Some(parent) = self.paths.socket_path.parent() {
+            std::fs::create_dir_all(parent)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+            }
+        }
+
+        if let Some(parent) = self.paths.daemon_log_file.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
@@ -198,5 +213,75 @@ impl Config {
     // Create a minimal config for CLI/client use (no daemon dependencies)
     pub fn for_client() -> Self {
         Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_config() -> (Config, PathBuf) {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before Unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "mcproc-config-test-{}-{suffix}",
+            std::process::id()
+        ));
+        let mut config = Config::default();
+        config.paths.data_dir = root.join("data");
+        config.paths.log_dir = root.join("runtime/log");
+        config.paths.pid_file = root.join("runtime/mcprocd.pid");
+        config.paths.socket_path = root.join("runtime/mcprocd.sock");
+        config.paths.daemon_log_file = root.join("state/log/mcprocd.log");
+        (config, root)
+    }
+
+    #[test]
+    fn ensure_directories_creates_daemon_log_parent() {
+        let (config, root) = test_config();
+
+        config.ensure_directories().unwrap();
+
+        assert!(config.daemon_log_file().parent().unwrap().is_dir());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_directories_sets_private_runtime_and_log_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (config, root) = test_config();
+        std::fs::create_dir_all(config.paths.socket_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&config.paths.log_dir).unwrap();
+        std::fs::set_permissions(
+            config.paths.socket_path.parent().unwrap(),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+        std::fs::set_permissions(
+            &config.paths.log_dir,
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+
+        config.ensure_directories().unwrap();
+
+        let runtime_mode = std::fs::metadata(config.paths.socket_path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let log_mode = std::fs::metadata(&config.paths.log_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(runtime_mode, 0o700);
+        assert_eq!(log_mode, 0o700);
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/mcproc/src/daemon/api/grpc/log_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/log_handlers.rs
@@ -8,6 +8,7 @@ use tracing::{debug, error, info};
 
 const MAX_LOG_LINES: usize = 10_000;
 const MAX_GREP_CONTEXT: usize = 1_000;
+const MAX_GREP_MATCHES: usize = 1_000;
 
 fn clamp_tail(tail: u32) -> usize {
     (tail as usize).min(MAX_LOG_LINES)
@@ -581,6 +582,10 @@ async fn grep_log_file(
             }
         }
 
+        if results.len() >= MAX_GREP_MATCHES {
+            return Ok(results);
+        }
+
         // Check if current line matches the pattern
         if pattern.is_match(&parsed.original) {
             // Create context_before from the buffer
@@ -607,6 +612,9 @@ async fn grep_log_file(
 
     // Finalize any remaining pending matches (may have incomplete after-context)
     for pending in pending_matches {
+        if results.len() >= MAX_GREP_MATCHES {
+            break;
+        }
         results.push(GrepMatch {
             matched_line: Some(pending.matched_line),
             context_before: pending.context_before,
@@ -703,6 +711,29 @@ mod tests {
             matches[0].matched_line.as_ref().unwrap().content,
             "after invalid"
         );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn grep_log_file_limits_matches_to_one_thousand() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "mcproc-grep-limit-{}-{suffix}.log",
+            std::process::id()
+        ));
+        let contents = (0..3_000)
+            .map(|line| format!("matching line {line}\n"))
+            .collect::<String>();
+        std::fs::write(&path, contents).unwrap();
+
+        let matches = grep_log_file(&path, &regex::Regex::new(".*").unwrap(), 0, 0, None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(matches.len(), 1_000);
         std::fs::remove_file(path).unwrap();
     }
 

--- a/mcproc/src/daemon/api/grpc/log_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/log_handlers.rs
@@ -6,6 +6,17 @@ use proto::*;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
 
+const MAX_LOG_LINES: usize = 10_000;
+const MAX_GREP_CONTEXT: usize = 1_000;
+
+fn clamp_tail(tail: u32) -> usize {
+    (tail as usize).min(MAX_LOG_LINES)
+}
+
+fn clamp_grep_context(value: u32) -> usize {
+    (value as usize).min(MAX_GREP_CONTEXT)
+}
+
 impl GrpcService {
     pub(super) async fn get_logs_impl(
         &self,
@@ -15,7 +26,7 @@ impl GrpcService {
 
         let project = req.project.clone();
         let process_names = req.process_names.clone();
-        let tail = req.tail.unwrap_or(100) as usize;
+        let tail = clamp_tail(req.tail.unwrap_or(100));
         let follow = req.follow.unwrap_or(false);
         let include_events = req.include_events.unwrap_or(false);
 
@@ -41,8 +52,6 @@ impl GrpcService {
 
         // Create stream
         let stream = async_stream::try_stream! {
-            use tokio::io::{AsyncBufReadExt, BufReader};
-            use tokio::fs::File;
             use crate::common::process_key::ProcessKey;
 
             // First, send existing logs if tail is requested
@@ -66,27 +75,13 @@ impl GrpcService {
                     let log_file = log_hub.get_log_file_path_for_key(&key);
 
                     if log_file.exists() {
-                        match File::open(&log_file).await {
-                            Ok(file) => {
-                                let reader = BufReader::new(file);
-                                let mut lines = reader.lines();
-                                let mut all_lines = Vec::new();
-
-                                // Read all lines
-                                while let Ok(Some(line)) = lines.next_line().await {
-                                    all_lines.push(line);
-                                }
-
-                                // Get tail lines
-                                let start_idx = all_lines.len().saturating_sub(tail);
-                                let mut line_num = start_idx as u32;
-
-                                for line in &all_lines[start_idx..] {
-                                    line_num += 1;
+                        match tail_log_lines(&log_file, tail).await {
+                            Ok((start_idx, lines)) => {
+                                for (line_num, line) in lines.iter().enumerate() {
                                     let (timestamp, level, content) = parse_log_line(line);
 
                                     let log_entry = LogEntry {
-                                        line_number: line_num,
+                                        line_number: (start_idx + line_num + 1) as u32,
                                         content,
                                         timestamp,
                                         level: level as i32,
@@ -99,7 +94,7 @@ impl GrpcService {
                                 }
                             }
                             Err(e) => {
-                                error!("Failed to open log file for {}/{}: {}",
+                                error!("Failed to read log file for {}/{}: {}",
                                     process_info.project, process_info.name, e);
                             }
                         }
@@ -225,6 +220,19 @@ impl GrpcService {
     }
 }
 
+fn grep_log_path(
+    log_hub: &crate::daemon::log::LogHub,
+    project: &str,
+    name: &str,
+) -> Result<std::path::PathBuf, Status> {
+    crate::common::validation::validate_project_name(project)
+        .map_err(|e| Status::invalid_argument(format!("Invalid project name: {e}")))?;
+    crate::common::validation::validate_process_name(name)
+        .map_err(|e| Status::invalid_argument(format!("Invalid process name: {e}")))?;
+    let key = crate::common::process_key::ProcessKey::new(project, name);
+    Ok(log_hub.get_log_file_path_for_key(&key))
+}
+
 // Helper function to parse log lines
 fn parse_log_line(line: &str) -> (Option<prost_types::Timestamp>, log_entry::LogLevel, String) {
     // Expected format: "2025-07-15T03:13:12.375+00:00 [INFO] Log message"
@@ -267,17 +275,7 @@ impl GrpcService {
     ) -> Result<Response<GrepLogsResponse>, Status> {
         let req = request.into_inner();
 
-        // Construct the log file path
-        let project = req.project.clone();
-
-        // Use project-based directory structure
-        let log_file = self
-            .log_hub
-            .config
-            .paths
-            .log_dir
-            .join(&project)
-            .join(format!("{}.log", req.name));
+        let log_file = grep_log_path(&self.log_hub, &req.project, &req.name)?;
 
         // If file doesn't exist, return error
         if !log_file.exists() {
@@ -296,9 +294,9 @@ impl GrpcService {
             .map_err(|e| Status::invalid_argument(format!("Invalid regex pattern: {}", e)))?;
 
         // Determine context settings
-        let context = req.context.unwrap_or(3) as usize;
-        let before = req.before.map(|b| b as usize).unwrap_or(context);
-        let after = req.after.map(|a| a as usize).unwrap_or(context);
+        let context = clamp_grep_context(req.context.unwrap_or(3));
+        let before = req.before.map(clamp_grep_context).unwrap_or(context);
+        let after = req.after.map(clamp_grep_context).unwrap_or(context);
 
         // Read and process logs from file
         info!(
@@ -390,6 +388,8 @@ fn parse_duration(duration_str: &str) -> Result<chrono::Duration, String> {
 
 // Helper function to parse time strings
 fn parse_time_string(time_str: &str) -> Result<chrono::DateTime<chrono::Utc>, String> {
+    use chrono::TimeZone;
+
     let time_str = time_str.trim();
 
     // Try different time formats
@@ -402,26 +402,79 @@ fn parse_time_string(time_str: &str) -> Result<chrono::DateTime<chrono::Utc>, St
 
     for format in &formats {
         if let Ok(naive_time) = chrono::NaiveDateTime::parse_from_str(time_str, format) {
-            return Ok(chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
-                naive_time,
-                chrono::Utc,
-            ));
+            return chrono::Local
+                .from_local_datetime(&naive_time)
+                .single()
+                .map(|date_time| date_time.with_timezone(&chrono::Utc))
+                .ok_or_else(|| format!("Local time is ambiguous or does not exist: {time_str}"));
         }
 
         // For time-only formats, combine with today's date
         if format.starts_with("%H") {
             if let Ok(naive_time) = chrono::NaiveTime::parse_from_str(time_str, format) {
-                let today = chrono::Utc::now().date_naive();
+                let today = chrono::Local::now().date_naive();
                 let naive_datetime = today.and_time(naive_time);
-                return Ok(chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
-                    naive_datetime,
-                    chrono::Utc,
-                ));
+                return chrono::Local
+                    .from_local_datetime(&naive_datetime)
+                    .single()
+                    .map(|date_time| date_time.with_timezone(&chrono::Utc))
+                    .ok_or_else(|| {
+                        format!("Local time is ambiguous or does not exist: {time_str}")
+                    });
             }
         }
     }
 
     Err(format!("Could not parse time: {}", time_str))
+}
+
+/// Read the next line as lossy UTF-8 (non-UTF-8 bytes are replaced, not fatal).
+/// Returns Ok(None) at EOF.
+async fn next_line_lossy<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut R,
+    bytes: &mut Vec<u8>,
+) -> Result<Option<String>, std::io::Error> {
+    use tokio::io::AsyncBufReadExt;
+
+    bytes.clear();
+    if reader.read_until(b'\n', bytes).await? == 0 {
+        return Ok(None);
+    }
+    if bytes.last() == Some(&b'\n') {
+        bytes.pop();
+    }
+    if bytes.last() == Some(&b'\r') {
+        bytes.pop();
+    }
+    Ok(Some(String::from_utf8_lossy(bytes).into_owned()))
+}
+
+async fn tail_log_lines(
+    log_file: &std::path::Path,
+    tail: usize,
+) -> Result<(usize, Vec<String>), std::io::Error> {
+    use std::collections::VecDeque;
+
+    let file = tokio::fs::File::open(log_file).await?;
+    let mut reader = tokio::io::BufReader::new(file);
+    let mut bytes = Vec::new();
+    let mut lines = VecDeque::with_capacity(tail);
+    let mut total_lines = 0usize;
+    while let Some(line) = next_line_lossy(&mut reader, &mut bytes).await? {
+        total_lines += 1;
+        if tail == 0 {
+            continue;
+        }
+        if lines.len() == tail {
+            lines.pop_front();
+        }
+        lines.push_back(line);
+    }
+
+    Ok((
+        total_lines.saturating_sub(lines.len()),
+        lines.into_iter().collect(),
+    ))
 }
 
 /// Parsed log line with original content preserved for pattern matching
@@ -463,12 +516,9 @@ async fn grep_log_file(
     until_time: Option<chrono::DateTime<chrono::Utc>>,
 ) -> Result<Vec<GrepMatch>, std::io::Error> {
     use std::collections::VecDeque;
-    use tokio::fs::File;
-    use tokio::io::{AsyncBufReadExt, BufReader};
-
-    let file = File::open(log_file).await?;
-    let reader = BufReader::new(file);
-    let mut lines = reader.lines();
+    let file = tokio::fs::File::open(log_file).await?;
+    let mut reader = tokio::io::BufReader::new(file);
+    let mut line_bytes = Vec::new();
 
     // Buffer for before-context lines (keeps only the last `before` lines)
     let mut before_buffer: VecDeque<ParsedLogLine> = VecDeque::with_capacity(before + 1);
@@ -478,8 +528,7 @@ async fn grep_log_file(
     let mut results: Vec<GrepMatch> = Vec::new();
 
     let mut line_num = 0u32;
-
-    while let Ok(Some(line)) = lines.next_line().await {
+    while let Some(line) = next_line_lossy(&mut reader, &mut line_bytes).await? {
         line_num += 1;
         let (timestamp, level, content) = parse_log_line(&line);
 
@@ -566,4 +615,105 @@ async fn grep_log_file(
     }
 
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        clamp_grep_context, clamp_tail, grep_log_file, grep_log_path, parse_time_string,
+        tail_log_lines, MAX_GREP_CONTEXT, MAX_LOG_LINES,
+    };
+    use crate::common::config::Config;
+    use crate::daemon::log::LogHub;
+    use crate::daemon::stream::StreamEventHub;
+    use chrono::{Local, TimeZone};
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn grep_log_path_rejects_traversal_and_stays_under_log_dir() {
+        let mut config = Config::default();
+        config.paths.log_dir = std::env::temp_dir().join("mcproc-grep-path-test");
+        let log_dir = config.paths.log_dir.clone();
+        let log_hub = LogHub::with_event_hub(Arc::new(config), Arc::new(StreamEventHub::new()));
+
+        assert!(grep_log_path(&log_hub, "project", "../../x").is_err());
+        assert!(grep_log_path(&log_hub, "../project", "process").is_err());
+        assert_eq!(
+            grep_log_path(&log_hub, "project", "process").unwrap(),
+            log_dir.join("project/process.log")
+        );
+    }
+
+    #[test]
+    fn log_request_sizes_are_clamped() {
+        assert_eq!(clamp_tail(u32::MAX), MAX_LOG_LINES);
+        assert_eq!(clamp_grep_context(u32::MAX), MAX_GREP_CONTEXT);
+        assert_eq!(clamp_grep_context(999), 999);
+    }
+
+    #[tokio::test]
+    async fn tail_log_lines_returns_last_lines_with_original_start_index() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before Unix epoch")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("mcproc-tail-{}-{suffix}.log", std::process::id()));
+        let contents = (1..=50)
+            .map(|line| format!("line {line}\n"))
+            .collect::<String>();
+        std::fs::write(&path, contents).unwrap();
+
+        let (start_idx, lines) = tail_log_lines(&path, 10).await.unwrap();
+
+        assert_eq!(start_idx, 40);
+        assert_eq!(lines.len(), 10);
+        assert_eq!(lines.first().unwrap(), "line 41");
+        assert_eq!(lines.last().unwrap(), "line 50");
+        assert_eq!(start_idx + 1, 41);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn grep_log_file_continues_after_invalid_utf8() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "mcproc-invalid-utf8-{}-{suffix}.log",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"before\ninvalid \xff bytes\ntarget after invalid\n").unwrap();
+
+        let matches = grep_log_file(
+            &path,
+            &regex::Regex::new("target").unwrap(),
+            0,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].matched_line.as_ref().unwrap().content,
+            "after invalid"
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn parse_time_string_interprets_naive_datetime_as_local() {
+        let expected = Local
+            .with_ymd_and_hms(2026, 1, 1, 12, 0, 0)
+            .single()
+            .expect("test time must be unambiguous")
+            .with_timezone(&chrono::Utc);
+
+        assert_eq!(parse_time_string("2026-01-01 12:00").unwrap(), expected);
+    }
 }

--- a/mcproc/src/daemon/api/grpc/process_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/process_handlers.rs
@@ -21,12 +21,41 @@ fn mcprocd_error_to_status(e: &McprocdError) -> Status {
     }
 }
 
+fn matches_status_filter(status: crate::daemon::process::ProcessStatus, filter: i32) -> bool {
+    let status: proto::ProcessStatus = status.into();
+    status as i32 == filter
+}
+
+fn validate_wait_timeout(wait_timeout: Option<u32>) -> Result<(), Status> {
+    if wait_timeout.is_some_and(|timeout| timeout > 3600) {
+        return Err(Status::invalid_argument(
+            "wait_timeout must not exceed 3600 seconds",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_status_filter(filter: i32) -> Result<(), Status> {
+    proto::ProcessStatus::try_from(filter)
+        .map(|_| ())
+        .map_err(|_| Status::invalid_argument(format!("Unknown status_filter value: {filter}")))
+}
+
+fn force_restart_stop_result(result: Result<(), McprocdError>) -> Result<(), Status> {
+    result.map_err(|error| {
+        Status::failed_precondition(format!(
+            "Failed to stop existing process before restart: {error}"
+        ))
+    })
+}
+
 impl GrpcService {
     pub(super) async fn start_process_impl(
         &self,
         request: Request<StartProcessRequest>,
     ) -> Result<Response<<Self as ProcessManagerService>::StartProcessStream>, Status> {
         let req = request.into_inner();
+        validate_wait_timeout(req.wait_timeout)?;
 
         // Validate process name
         if let Err(e) = crate::common::validation::validate_process_name(&req.name) {
@@ -62,9 +91,11 @@ impl GrpcService {
                 .get_process_by_name_or_id_with_project(&name, Some(project.as_str()))
             {
                 // Stop existing process
-                let _ = process_manager
-                    .stop_process(&existing.id, Some(project.as_str()), true) // Use force=true
-                    .await;
+                force_restart_stop_result(
+                    process_manager
+                        .stop_process(&existing.id, Some(project.as_str()), true)
+                        .await,
+                )?;
 
                 // Wait for process to be completely removed
                 process_manager
@@ -188,6 +219,7 @@ impl GrpcService {
         request: Request<RestartProcessRequest>,
     ) -> Result<Response<<Self as ProcessManagerService>::RestartProcessStream>, Status> {
         let req = request.into_inner();
+        validate_wait_timeout(req.wait_timeout)?;
         let name = req.name.clone();
         let project = req.project.clone();
         let wait_for_log = req.wait_for_log.clone();
@@ -306,6 +338,11 @@ impl GrpcService {
             processes.retain(|p| p.project == project_filter);
         }
 
+        if let Some(status_filter) = req.status_filter {
+            validate_status_filter(status_filter)?;
+            processes.retain(|p| matches_status_filter(p.get_status(), status_filter));
+        }
+
         let log_dir = self.config.paths.log_dir.clone();
         let process_infos: Vec<ProcessInfo> = processes
             .into_iter()
@@ -324,5 +361,50 @@ impl GrpcService {
         Ok(Response::new(ListProcessesResponse {
             processes: process_infos,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        force_restart_stop_result, matches_status_filter, validate_status_filter,
+        validate_wait_timeout,
+    };
+    use crate::daemon::error::McprocdError;
+    use crate::daemon::process::ProcessStatus;
+
+    #[test]
+    fn status_filter_selects_only_requested_status() {
+        let statuses = [ProcessStatus::Running, ProcessStatus::Stopped];
+        let running = statuses
+            .into_iter()
+            .filter(|status| matches_status_filter(*status, proto::ProcessStatus::Running as i32))
+            .collect::<Vec<_>>();
+
+        assert_eq!(running, vec![ProcessStatus::Running]);
+    }
+
+    #[test]
+    fn wait_timeout_is_limited_to_one_hour() {
+        assert!(validate_wait_timeout(Some(3600)).is_ok());
+        assert_eq!(
+            validate_wait_timeout(Some(3601)).unwrap_err().code(),
+            tonic::Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn undefined_status_filter_is_rejected() {
+        assert_eq!(
+            validate_status_filter(999).unwrap_err().code(),
+            tonic::Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn force_restart_propagates_stop_failure() {
+        let result =
+            force_restart_stop_result(Err(McprocdError::StopError("cannot stop".to_string())));
+        assert_eq!(result.unwrap_err().code(), tonic::Code::FailedPrecondition);
     }
 }

--- a/mcproc/src/daemon/api/grpc/service.rs
+++ b/mcproc/src/daemon/api/grpc/service.rs
@@ -8,6 +8,10 @@ use proto::*;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 
+fn uptime_seconds(now: DateTime<Utc>, start_time: DateTime<Utc>) -> u64 {
+    (now - start_time).num_seconds().max(0) as u64
+}
+
 pub struct GrpcService {
     pub(super) process_manager: Arc<ProcessManager>,
     pub(super) log_hub: Arc<LogHub>,
@@ -93,7 +97,7 @@ impl GrpcService {
     ) -> Result<Response<GetDaemonStatusResponse>, Status> {
         let pid = std::process::id();
         let now = Utc::now();
-        let uptime_seconds = (now - self.start_time).num_seconds() as u64;
+        let uptime_seconds = uptime_seconds(now, self.start_time);
 
         let active_processes = self.process_manager.get_all_processes().len() as u32;
 
@@ -110,5 +114,17 @@ impl GrpcService {
         };
 
         Ok(Response::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::uptime_seconds;
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn uptime_is_zero_when_clock_moves_backwards() {
+        let now = Utc::now();
+        assert_eq!(uptime_seconds(now, now + Duration::seconds(10)), 0);
     }
 }

--- a/mcproc/src/daemon/log/batch_writer.rs
+++ b/mcproc/src/daemon/log/batch_writer.rs
@@ -3,7 +3,7 @@ use crate::common::timestamp::format_datetime_utc_with_tz;
 use bytes::Bytes;
 use std::path::PathBuf;
 use tokio::fs::{File, OpenOptions};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tokio::time::{interval, Duration};
 use tracing::{debug, error, info};
@@ -72,9 +72,20 @@ impl BatchLogWriter {
         // Open file
         let mut file = OpenOptions::new()
             .create(true)
+            .read(true)
             .append(true)
             .open(&log_file_path)
             .await?;
+
+        let file_len = file.metadata().await?.len();
+        if file_len > 0 {
+            file.seek(std::io::SeekFrom::End(-1)).await?;
+            let mut last_byte = [0];
+            file.read_exact(&mut last_byte).await?;
+            if last_byte[0] != b'\n' {
+                file.write_all(b"\n").await?;
+            }
+        }
 
         info!(
             "Started batch log writer for {}/{}",
@@ -211,6 +222,21 @@ mod tests {
 
         let contents = wait_for_contents(&path, &["existing", "new-line"]).await;
         assert!(contents.starts_with("existing\n"), "contents: {contents:?}");
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn appending_to_partial_line_starts_a_new_line() {
+        let path = temp_log_path("append-partial");
+        tokio::fs::write(&path, "partial").await.unwrap();
+        let writer = BatchLogWriter::new(ProcessKey::new("p", "n"), path.clone())
+            .await
+            .unwrap();
+        writer.write(entry(b"new-line")).await.unwrap();
+        drop(writer);
+
+        let contents = wait_for_contents(&path, &["partial", "new-line"]).await;
+        assert!(contents.starts_with("partial\n"), "contents: {contents:?}");
         tokio::fs::remove_file(path).await.unwrap();
     }
 

--- a/mcproc/src/daemon/log/batch_writer.rs
+++ b/mcproc/src/daemon/log/batch_writer.rs
@@ -72,8 +72,7 @@ impl BatchLogWriter {
         // Open file
         let mut file = OpenOptions::new()
             .create(true)
-            .write(true)
-            .truncate(true)
+            .append(true)
             .open(&log_file_path)
             .await?;
 
@@ -88,12 +87,22 @@ impl BatchLogWriter {
 
         loop {
             tokio::select! {
-                Some(entry) = rx.recv() => {
-                    batch.push(entry);
+                entry = rx.recv() => {
+                    match entry {
+                        Some(entry) => {
+                            batch.push(entry);
 
-                    // Write if batch is full
-                    if batch.len() >= WRITE_BATCH_SIZE {
-                        Self::flush_batch(&mut file, &mut batch).await?;
+                            // Write if batch is full
+                            if batch.len() >= WRITE_BATCH_SIZE {
+                                Self::flush_batch(&mut file, &mut batch).await?;
+                            }
+                        }
+                        None => {
+                            if !batch.is_empty() {
+                                Self::flush_batch(&mut file, &mut batch).await?;
+                            }
+                            break;
+                        }
                     }
                 }
                 _ = timer.tick() => {
@@ -101,13 +110,6 @@ impl BatchLogWriter {
                     if !batch.is_empty() {
                         Self::flush_batch(&mut file, &mut batch).await?;
                     }
-                }
-                else => {
-                    // Channel closed, write remaining batch
-                    if !batch.is_empty() {
-                        Self::flush_batch(&mut file, &mut batch).await?;
-                    }
-                    break;
                 }
             }
         }
@@ -163,5 +165,87 @@ impl Drop for BatchLogWriter {
             "Dropping BatchLogWriter for {}/{}",
             self.process_key.project, self.process_key.name
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn temp_log_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("mcproc-{label}-{}.log", Uuid::new_v4()))
+    }
+
+    fn entry(content: &'static [u8]) -> LogEntry {
+        LogEntry {
+            timestamp: chrono::Utc::now(),
+            content: Bytes::from_static(content),
+            is_stderr: false,
+        }
+    }
+
+    async fn wait_for_contents(path: &PathBuf, needles: &[&str]) -> String {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let contents = tokio::fs::read_to_string(path).await.unwrap_or_default();
+                if needles.iter().all(|needle| contents.contains(needle)) {
+                    return contents;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("log contents were not flushed before timeout")
+    }
+
+    #[tokio::test]
+    async fn appends_to_existing_log_file() {
+        let path = temp_log_path("append");
+        tokio::fs::write(&path, "existing\n").await.unwrap();
+        let writer = BatchLogWriter::new(ProcessKey::new("p", "n"), path.clone())
+            .await
+            .unwrap();
+        writer.write(entry(b"new-line")).await.unwrap();
+        drop(writer);
+
+        let contents = wait_for_contents(&path, &["existing", "new-line"]).await;
+        assert!(contents.starts_with("existing\n"), "contents: {contents:?}");
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn two_writers_append_without_overwriting_each_other() {
+        let path = temp_log_path("two-writers");
+        let first = BatchLogWriter::new(ProcessKey::new("p", "n"), path.clone())
+            .await
+            .unwrap();
+        first.write(entry(b"from-first")).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        let second = BatchLogWriter::new(ProcessKey::new("p", "n"), path.clone())
+            .await
+            .unwrap();
+        second.write(entry(b"from-second")).await.unwrap();
+        drop(first);
+        drop(second);
+
+        wait_for_contents(&path, &["from-first", "from-second"]).await;
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn writer_task_exits_when_channel_closes() {
+        let path = temp_log_path("channel-close");
+        let (tx, rx) = mpsc::channel(1);
+        drop(tx);
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            BatchLogWriter::writer_task(ProcessKey::new("p", "n"), path.clone(), rx),
+        )
+        .await
+        .expect("writer task did not exit after channel close")
+        .unwrap();
+        tokio::fs::remove_file(path).await.unwrap();
     }
 }

--- a/mcproc/src/daemon/mod.rs
+++ b/mcproc/src/daemon/mod.rs
@@ -188,11 +188,8 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Give processes time to shut down gracefully
-    tokio::time::sleep(tokio::time::Duration::from_millis(
-        config.daemon.daemon_shutdown_timeout_ms,
-    ))
-    .await;
+    // Briefly allow buffered logs to flush before removing the PID file.
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
     // Remove PID file
     if let Err(e) = std::fs::remove_file(&config.paths.pid_file) {

--- a/mcproc/src/daemon/process/hyperlog.rs
+++ b/mcproc/src/daemon/process/hyperlog.rs
@@ -13,6 +13,7 @@ use tracing::{debug, error, info};
 const CHUNK_SIZE: usize = 8192; // 8KB chunks
 const BATCH_SIZE: usize = 4; // Process 4 chunks at a time for better responsiveness
 const BATCH_TIMEOUT_MS: u64 = 50; // Process after 50ms for better responsiveness
+const CHUNK_CHANNEL_CAPACITY: usize = 1024;
 
 pub struct HyperLogConfig {
     pub stream_name: &'static str,
@@ -31,13 +32,13 @@ pub struct HyperLogConfig {
 
 pub struct HyperLogStreamer {
     config: HyperLogConfig,
-    chunk_tx: mpsc::UnboundedSender<Bytes>,
-    chunk_rx: mpsc::UnboundedReceiver<Bytes>,
+    chunk_tx: mpsc::Sender<Bytes>,
+    chunk_rx: mpsc::Receiver<Bytes>,
 }
 
 impl HyperLogStreamer {
     pub fn new(config: HyperLogConfig) -> Self {
-        let (chunk_tx, chunk_rx) = mpsc::unbounded_channel();
+        let (chunk_tx, chunk_rx) = mpsc::channel(CHUNK_CHANNEL_CAPACITY);
         Self {
             config,
             chunk_tx,
@@ -93,7 +94,7 @@ impl HyperLogStreamer {
                     Ok(n) => {
                         // Send chunk without copying
                         let chunk = buffer.split_to(n).freeze();
-                        if chunk_tx.send(chunk).is_err() {
+                        if chunk_tx.send(chunk).await.is_err() {
                             debug!("Channel closed, stopping reader");
                             break;
                         }
@@ -241,6 +242,13 @@ impl HyperLogStreamer {
                         }
                     }
                 }
+            }
+
+            if !line_buffer.is_empty() {
+                line_buffer.push(b'\n');
+                let mut final_batch = vec![Bytes::new()];
+                Self::process_batch(&config, &mut final_batch, &mut line_buffer, &batch_writer)
+                    .await;
             }
 
             // Close ready channel if needed
@@ -392,5 +400,62 @@ impl HyperLogStreamer {
                     .publish_log_event(&config.process_key, line, config.is_stderr);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::config::Config;
+    use crate::daemon::stream::StreamEventHub;
+    use tokio::io::AsyncWriteExt;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn flushes_final_line_without_newline_at_eof() {
+        let root = std::env::temp_dir().join(format!("mcproc-hyperlog-{}", Uuid::new_v4()));
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let path = root.join("process.log");
+        let mut config = Config::default();
+        config.paths.log_dir = root.clone();
+        let event_hub = Arc::new(StreamEventHub::new());
+        let log_hub = Arc::new(LogHub::with_event_hub(Arc::new(config), event_hub));
+        let streamer = HyperLogStreamer::new(HyperLogConfig {
+            stream_name: "stdout",
+            process_key: ProcessKey::new("p", "n"),
+            log_pattern: None,
+            log_ready_tx: None,
+            pattern_matched: Arc::new(Mutex::new(false)),
+            matched_line: Arc::new(Mutex::new(None)),
+            timeout_occurred: Arc::new(Mutex::new(false)),
+            wait_timeout: None,
+            default_wait_timeout_secs: 1,
+            is_stderr: false,
+            log_file_path: Some(path.clone()),
+            log_hub,
+        });
+        let (mut input, output) = tokio::io::duplex(64);
+        let handle = streamer.spawn(output).await;
+        input.write_all(b"line1\npartial").await.unwrap();
+        drop(input);
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), handle)
+            .await
+            .expect("hyperlog tasks did not finish")
+            .unwrap();
+
+        let contents = tokio::time::timeout(tokio::time::Duration::from_secs(2), async {
+            loop {
+                let contents = tokio::fs::read_to_string(&path).await.unwrap_or_default();
+                if contents.contains("partial") {
+                    break contents;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("partial line was not flushed");
+        assert!(contents.contains("line1"));
+        assert!(contents.contains("partial"));
+        tokio::fs::remove_dir_all(root).await.unwrap();
     }
 }

--- a/mcproc/src/daemon/process/launcher.rs
+++ b/mcproc/src/daemon/process/launcher.rs
@@ -12,6 +12,23 @@ use tokio::process::Command;
 use tracing::{debug, error, info};
 use uuid::Uuid;
 
+fn shell_quote_args(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| {
+            if !arg.is_empty()
+                && arg
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || b"_@%+=:,./-".contains(&byte))
+            {
+                arg.clone()
+            } else {
+                format!("'{}'", arg.replace('\'', "'\\''"))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Parameters for launching a process
 pub struct LaunchProcessParams {
     pub name: String,
@@ -55,7 +72,7 @@ impl ProcessLauncher {
         // Build command - always use shell execution for consistency
         let shell_command = if !params.args.is_empty() {
             // Convert args to shell command
-            params.args.join(" ")
+            shell_quote_args(&params.args)
         } else if let Some(cmd_str) = params.cmd {
             // Use the cmd string as-is
             cmd_str
@@ -222,5 +239,54 @@ impl ProcessLauncher {
                     })
             })
             .transpose()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    #[test]
+    fn shell_quotes_direct_command_arguments() {
+        assert_eq!(
+            shell_quote_args(&["echo".into(), "a b".into()]),
+            "echo 'a b'"
+        );
+        assert_eq!(
+            shell_quote_args(&["echo".into(), "$HOME".into()]),
+            "echo '$HOME'"
+        );
+        assert_eq!(
+            shell_quote_args(&["printf".into(), "don't".into()]),
+            "printf 'don'\\''t'"
+        );
+    }
+
+    #[tokio::test]
+    async fn launch_process_preserves_direct_argument_boundaries() {
+        let launcher = ProcessLauncher::new();
+        let (mut child, _) = launcher
+            .launch_process(LaunchProcessParams {
+                name: "quoted-args".into(),
+                project: "test".into(),
+                cmd: None,
+                args: vec!["printf".into(), "%s".into(), "a b;$HOME".into()],
+                cwd: None,
+                env: None,
+                toolchain: None,
+            })
+            .await
+            .unwrap();
+        let mut output = String::new();
+        child
+            .stdout
+            .take()
+            .unwrap()
+            .read_to_string(&mut output)
+            .await
+            .unwrap();
+        assert!(child.wait().await.unwrap().success());
+        assert_eq!(output, "a b;$HOME");
     }
 }

--- a/mcproc/src/daemon/process/manager.rs
+++ b/mcproc/src/daemon/process/manager.rs
@@ -25,6 +25,34 @@ pub struct ProcessManager {
     event_hub: Option<SharedStreamEventHub>,
 }
 
+struct ProcessNameReservation {
+    registry: ProcessRegistry,
+    key: ProcessKey,
+    release_on_drop: bool,
+}
+
+impl ProcessNameReservation {
+    fn new(registry: ProcessRegistry, key: ProcessKey) -> Self {
+        Self {
+            registry,
+            key,
+            release_on_drop: true,
+        }
+    }
+
+    fn keep(mut self) {
+        self.release_on_drop = false;
+    }
+}
+
+impl Drop for ProcessNameReservation {
+    fn drop(&mut self) {
+        if self.release_on_drop {
+            self.registry.release_name(&self.key);
+        }
+    }
+}
+
 impl ProcessManager {
     pub fn with_event_hub(
         config: Arc<Config>,
@@ -103,8 +131,13 @@ impl ProcessManager {
                 .to_string()
         });
 
-        // Check if process already exists
-        if let Some(existing) = self.registry.get_process_by_name(&name) {
+        let process_key = ProcessKey::new(project.clone(), name.clone());
+
+        // Remove a reusable terminal entry before atomically reserving this project/name.
+        if let Some(existing) = self
+            .registry
+            .get_process_by_name_with_project(&name, &project)
+        {
             match existing.get_status() {
                 ProcessStatus::Running => {
                     return Err(McprocdError::ProcessAlreadyExists(name));
@@ -119,10 +152,15 @@ impl ProcessManager {
                     self.registry.remove_process(&existing.id);
                 }
                 _ => {
-                    // Starting or Stopping states should be kept
+                    return Err(McprocdError::ProcessAlreadyExists(name));
                 }
             }
         }
+
+        if !self.registry.try_reserve_name(process_key.clone()) {
+            return Err(McprocdError::ProcessAlreadyExists(name));
+        }
+        let reservation = ProcessNameReservation::new(self.registry.clone(), process_key);
 
         // Parse wait pattern if provided
         let log_pattern = self.launcher.parse_wait_pattern(wait_for_log.clone())?;
@@ -177,6 +215,7 @@ impl ProcessManager {
 
         // Add to registry
         self.registry.add_process(proxy_arc.clone());
+        reservation.keep();
 
         // Publish Starting event
         self.publish_process_event(crate::daemon::process::event::ProcessEvent::Starting {
@@ -448,14 +487,23 @@ impl ProcessManager {
                 // Try force kill as last resort
                 if !force {
                     match tokio::time::timeout(
-                        tokio::time::Duration::from_secs(2),
+                        tokio::time::Duration::from_secs(5),
                         process.stop(true, self.config.process.restart.process_stop_timeout_ms),
                     )
                     .await
                     {
                         Ok(Ok(())) => info!("Process {} force killed", name),
-                        _ => error!("Failed to force kill process {}", name),
+                        Ok(Err(e)) => return Err(McprocdError::StopError(e)),
+                        Err(_) => {
+                            return Err(McprocdError::StopError(format!(
+                                "Timed out force killing process {name}"
+                            )))
+                        }
                     }
+                } else {
+                    return Err(McprocdError::StopError(format!(
+                        "Timed out stopping process {name}"
+                    )));
                 }
             }
         }
@@ -827,6 +875,94 @@ impl ProcessManager {
                     name, e
                 );
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::stream::StreamEventHub;
+    use uuid::Uuid;
+
+    fn test_manager() -> (ProcessManager, PathBuf) {
+        let root = std::env::temp_dir().join(format!("mcproc-manager-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let mut config = Config::default();
+        config.paths.data_dir = root.clone();
+        config.paths.log_dir = root.join("logs");
+        config.process.restart.process_stop_timeout_ms = 500;
+        let config = Arc::new(config);
+        let event_hub = Arc::new(StreamEventHub::new());
+        let log_hub = Arc::new(LogHub::with_event_hub(config.clone(), event_hub.clone()));
+        (
+            ProcessManager::with_event_hub(config, log_hub, event_hub),
+            root,
+        )
+    }
+
+    async fn start_sleep(
+        manager: &ProcessManager,
+        name: &str,
+        project: &str,
+    ) -> Result<Arc<ProxyInfo>> {
+        manager
+            .start_process_with_log_stream(
+                name.to_string(),
+                Some(project.to_string()),
+                None,
+                vec!["sleep".to_string(), "5".to_string()],
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .map(|result| result.0)
+    }
+
+    #[tokio::test]
+    async fn permits_same_process_name_in_different_projects() {
+        let (manager, root) = test_manager();
+        let first = start_sleep(&manager, "shared-name", "a").await.unwrap();
+        let second = start_sleep(&manager, "shared-name", "b").await.unwrap();
+        assert_eq!(manager.registry.get_all_processes().len(), 2);
+        manager
+            .stop_process(&first.id, Some("a"), true)
+            .await
+            .unwrap();
+        manager
+            .stop_process(&second.id, Some("b"), true)
+            .await
+            .unwrap();
+        tokio::fs::remove_dir_all(root).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_starts_reserve_name_atomically() {
+        for _ in 0..10 {
+            let (manager, root) = test_manager();
+            let (first, second) = tokio::join!(
+                start_sleep(&manager, "same-name", "same-project"),
+                start_sleep(&manager, "same-name", "same-project")
+            );
+            assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+            let error = match (first, second) {
+                (Err(error), _) | (_, Err(error)) => error,
+                _ => unreachable!(),
+            };
+            assert!(
+                matches!(error, McprocdError::ProcessAlreadyExists(_)),
+                "{error:?}"
+            );
+            let processes = manager.registry.get_processes_by_project("same-project");
+            assert_eq!(processes.len(), 1);
+            manager
+                .stop_process(&processes[0].id, Some("same-project"), true)
+                .await
+                .unwrap();
+            tokio::fs::remove_dir_all(root).await.unwrap();
         }
     }
 }

--- a/mcproc/src/daemon/process/proxy.rs
+++ b/mcproc/src/daemon/process/proxy.rs
@@ -250,6 +250,8 @@ impl ProxyInfo {
             for child_pid in &child_pids {
                 let _ = Self::send_signal(*child_pid, Signal::SIGKILL);
             }
+
+            self.confirm_stopped_after_force_kill().await?;
         }
 
         self.set_status(ProcessStatus::Stopped);
@@ -264,6 +266,23 @@ impl ProxyInfo {
         // process dies, and will be cleaned up when ProxyInfo is dropped.
 
         Ok(())
+    }
+
+    #[cfg(unix)]
+    async fn confirm_stopped_after_force_kill(&self) -> Result<(), String> {
+        let timeout = tokio::time::Duration::from_secs(2);
+        let start = tokio::time::Instant::now();
+        while start.elapsed() < timeout {
+            if !Self::is_process_alive(self.pid) {
+                return Ok(());
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+
+        Err(format!(
+            "Process {} (PID {}) is still alive after SIGKILL",
+            self.name, self.pid
+        ))
     }
 
     pub fn set_detected_port(&self, port: u16) {
@@ -318,5 +337,56 @@ impl ProxyInfo {
 
         find_descendants(&system, parent_pid, &mut child_pids);
         child_pids
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::daemon::process::types::ProxyInfoParams;
+    use uuid::Uuid;
+
+    fn proxy_for_pid(pid: u32) -> ProxyInfo {
+        ProxyInfo::new(ProxyInfoParams {
+            id: Uuid::new_v4().to_string(),
+            name: "stop-test".into(),
+            project: "test".into(),
+            cmd: None,
+            args: Vec::new(),
+            cwd: None,
+            env: None,
+            wait_for_log: None,
+            wait_timeout: None,
+            toolchain: None,
+            pid,
+        })
+    }
+
+    #[tokio::test]
+    async fn force_stop_errors_when_process_survives_sigkill() {
+        let proxy = proxy_for_pid(std::process::id());
+        let result = proxy.confirm_stopped_after_force_kill().await;
+        assert!(
+            result.is_err(),
+            "live process unexpectedly reported as stopped"
+        );
+        assert_ne!(proxy.get_status(), ProcessStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn force_stop_succeeds_for_killable_process() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        let pid = child.id().unwrap();
+        let waiter = tokio::spawn(async move { child.wait().await.unwrap() });
+        let proxy = proxy_for_pid(pid);
+        proxy.stop(true, 1_000).await.unwrap();
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), waiter)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(proxy.get_status(), ProcessStatus::Stopped);
     }
 }

--- a/mcproc/src/daemon/process/registry.rs
+++ b/mcproc/src/daemon/process/registry.rs
@@ -72,8 +72,13 @@ impl ProcessRegistry {
 
     /// Get process by name or ID
     pub fn get_process_by_name_or_id(&self, name_or_id: &str) -> Option<Arc<ProxyInfo>> {
-        self.get_process_by_name(name_or_id)
-            .or_else(|| self.get_process_by_id(name_or_id))
+        if uuid::Uuid::parse_str(name_or_id).is_ok() {
+            self.get_process_by_id(name_or_id)
+                .or_else(|| self.get_process_by_name(name_or_id))
+        } else {
+            self.get_process_by_name(name_or_id)
+                .or_else(|| self.get_process_by_id(name_or_id))
+        }
     }
 
     /// Get process by name or ID with project filter
@@ -83,15 +88,17 @@ impl ProcessRegistry {
         project: Option<&str>,
     ) -> Option<Arc<ProxyInfo>> {
         if let Some(project_name) = project {
-            if let Some(process) = self.get_process_by_name_with_project(name_or_id, project_name) {
-                return Some(process);
+            let id_lookup = || {
+                self.get_process_by_id(name_or_id)
+                    .filter(|process| process.project == project_name)
+            };
+            let name_lookup = || self.get_process_by_name_with_project(name_or_id, project_name);
+
+            if uuid::Uuid::parse_str(name_or_id).is_ok() {
+                id_lookup().or_else(name_lookup)
+            } else {
+                name_lookup().or_else(id_lookup)
             }
-            if let Some(process) = self.get_process_by_id(name_or_id) {
-                if process.project == project_name {
-                    return Some(process);
-                }
-            }
-            None
         } else {
             self.get_process_by_name_or_id(name_or_id)
         }
@@ -182,6 +189,31 @@ mod tests {
                 .unwrap()
                 .id,
             process_b.id
+        );
+    }
+
+    #[test]
+    fn uuid_lookup_wins_over_matching_process_name() {
+        let registry = ProcessRegistry::new();
+        let uuid = uuid::Uuid::new_v4().to_string();
+        let process_a = proxy(&uuid, "process-a", "project");
+        let process_b = proxy("process-b-id", &uuid, "project");
+        registry.add_process(process_a.clone());
+        registry.add_process(process_b);
+
+        assert_eq!(
+            registry
+                .get_process_by_name_or_id_with_project(&uuid, Some("project"))
+                .unwrap()
+                .id,
+            process_a.id
+        );
+        assert_eq!(
+            registry
+                .get_process_by_name_or_id_with_project(&uuid, None)
+                .unwrap()
+                .id,
+            process_a.id
         );
     }
 }

--- a/mcproc/src/daemon/process/registry.rs
+++ b/mcproc/src/daemon/process/registry.rs
@@ -1,4 +1,6 @@
+use crate::common::process_key::ProcessKey;
 use crate::daemon::process::proxy::ProxyInfo;
+use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use std::sync::Arc;
 
@@ -6,12 +8,14 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct ProcessRegistry {
     processes: Arc<DashMap<String, Arc<ProxyInfo>>>,
+    reserved_names: Arc<DashMap<ProcessKey, ()>>,
 }
 
 impl ProcessRegistry {
     pub fn new() -> Self {
         Self {
             processes: Arc::new(DashMap::new()),
+            reserved_names: Arc::new(DashMap::new()),
         }
     }
 
@@ -22,7 +26,35 @@ impl ProcessRegistry {
 
     /// Remove a process from the registry
     pub fn remove_process(&self, id: &str) -> Option<Arc<ProxyInfo>> {
-        self.processes.remove(id).map(|(_, v)| v)
+        self.processes.remove(id).map(|(_, proxy)| {
+            self.release_name(&proxy.key);
+            proxy
+        })
+    }
+
+    pub fn try_reserve_name(&self, key: ProcessKey) -> bool {
+        match self.reserved_names.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(());
+                true
+            }
+            Entry::Occupied(_) => false,
+        }
+    }
+
+    pub fn release_name(&self, key: &ProcessKey) {
+        self.reserved_names.remove(key);
+    }
+
+    pub fn get_process_by_name_with_project(
+        &self,
+        name: &str,
+        project: &str,
+    ) -> Option<Arc<ProxyInfo>> {
+        self.processes
+            .iter()
+            .find(|entry| entry.name == name && entry.project == project)
+            .map(|entry| entry.value().clone())
     }
 
     /// Get process by ID
@@ -40,8 +72,8 @@ impl ProcessRegistry {
 
     /// Get process by name or ID
     pub fn get_process_by_name_or_id(&self, name_or_id: &str) -> Option<Arc<ProxyInfo>> {
-        self.get_process_by_id(name_or_id)
-            .or_else(|| self.get_process_by_name(name_or_id))
+        self.get_process_by_name(name_or_id)
+            .or_else(|| self.get_process_by_id(name_or_id))
     }
 
     /// Get process by name or ID with project filter
@@ -51,17 +83,15 @@ impl ProcessRegistry {
         project: Option<&str>,
     ) -> Option<Arc<ProxyInfo>> {
         if let Some(project_name) = project {
-            // First try ID lookup
+            if let Some(process) = self.get_process_by_name_with_project(name_or_id, project_name) {
+                return Some(process);
+            }
             if let Some(process) = self.get_process_by_id(name_or_id) {
                 if process.project == project_name {
                     return Some(process);
                 }
             }
-            // Then try name lookup with project filter
-            self.processes
-                .iter()
-                .find(|entry| entry.name == name_or_id && entry.project == project_name)
-                .map(|entry| entry.value().clone())
+            None
         } else {
             self.get_process_by_name_or_id(name_or_id)
         }
@@ -105,5 +135,53 @@ impl ProcessRegistry {
 impl Default for ProcessRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProcessRegistry;
+    use crate::daemon::process::proxy::ProxyInfo;
+    use crate::daemon::process::types::ProxyInfoParams;
+    use std::sync::Arc;
+
+    fn proxy(id: &str, name: &str, project: &str) -> Arc<ProxyInfo> {
+        Arc::new(ProxyInfo::new(ProxyInfoParams {
+            id: id.to_string(),
+            name: name.to_string(),
+            project: project.to_string(),
+            cmd: None,
+            args: Vec::new(),
+            cwd: None,
+            env: None,
+            wait_for_log: None,
+            wait_timeout: None,
+            toolchain: None,
+            pid: 0,
+        }))
+    }
+
+    #[test]
+    fn name_lookup_wins_over_uuid_lookup() {
+        let registry = ProcessRegistry::new();
+        let process_a = proxy("ambiguous", "process-a", "project");
+        let process_b = proxy("process-b-id", "ambiguous", "project");
+        registry.add_process(process_a);
+        registry.add_process(process_b.clone());
+
+        assert_eq!(
+            registry
+                .get_process_by_name_or_id_with_project("ambiguous", Some("project"))
+                .unwrap()
+                .id,
+            process_b.id
+        );
+        assert_eq!(
+            registry
+                .get_process_by_name_or_id_with_project("ambiguous", None)
+                .unwrap()
+                .id,
+            process_b.id
+        );
     }
 }

--- a/mcproc/src/daemon/process/toolchain.rs
+++ b/mcproc/src/daemon/process/toolchain.rs
@@ -9,25 +9,21 @@ pub struct Toolchain {
     pub command_template: &'static str,
     /// The display template for logging
     pub display_template: &'static str,
-    /// Quote style for shell command: true for double quotes, false for single quotes
-    pub use_double_quotes: bool,
 }
 
 impl Toolchain {
     /// mise toolchain
     pub const MISE: Self = Self {
         name: "mise",
-        command_template: "mise exec -- sh -c \"{cmd}\"",
+        command_template: "mise exec -- sh -c '{cmd}'",
         display_template: "mise exec -- sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// asdf toolchain
     pub const ASDF: Self = Self {
         name: "asdf",
-        command_template: "asdf exec sh -c \"{cmd}\"",
+        command_template: "asdf exec sh -c '{cmd}'",
         display_template: "asdf exec sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// nvm toolchain
@@ -35,63 +31,55 @@ impl Toolchain {
         name: "nvm",
         command_template: "bash -c 'source \"$NVM_DIR/nvm.sh\" && {cmd}'",
         display_template: "nvm (bash) -c '{cmd}'",
-        use_double_quotes: false,
     };
 
     /// rbenv toolchain
     pub const RBENV: Self = Self {
         name: "rbenv",
-        command_template: "rbenv exec sh -c \"{cmd}\"",
+        command_template: "rbenv exec sh -c '{cmd}'",
         display_template: "rbenv exec sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// pyenv toolchain
     pub const PYENV: Self = Self {
         name: "pyenv",
-        command_template: "pyenv exec sh -c \"{cmd}\"",
+        command_template: "pyenv exec sh -c '{cmd}'",
         display_template: "pyenv exec sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// nodenv toolchain
     pub const NODENV: Self = Self {
         name: "nodenv",
-        command_template: "nodenv exec sh -c \"{cmd}\"",
+        command_template: "nodenv exec sh -c '{cmd}'",
         display_template: "nodenv exec sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// jenv toolchain
     pub const JENV: Self = Self {
         name: "jenv",
-        command_template: "jenv exec sh -c \"{cmd}\"",
+        command_template: "jenv exec sh -c '{cmd}'",
         display_template: "jenv exec sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// tfenv toolchain
     pub const TFENV: Self = Self {
         name: "tfenv",
-        command_template: "tfenv exec sh -c \"{cmd}\"",
+        command_template: "tfenv exec sh -c '{cmd}'",
         display_template: "tfenv exec sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// goenv toolchain
     pub const GOENV: Self = Self {
         name: "goenv",
-        command_template: "goenv exec sh -c \"{cmd}\"",
+        command_template: "goenv exec sh -c '{cmd}'",
         display_template: "goenv exec sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// rustup toolchain
     pub const RUSTUP: Self = Self {
         name: "rustup",
-        command_template: "rustup run stable sh -c \"{cmd}\"",
+        command_template: "rustup run stable sh -c '{cmd}'",
         display_template: "rustup run stable sh -c '{cmd}'",
-        use_double_quotes: true,
     };
 
     /// All supported toolchains
@@ -124,11 +112,7 @@ impl Toolchain {
 
     /// Wrap command with toolchain-specific execution
     pub fn wrap_command(&self, shell_command: &str) -> (String, String) {
-        let escaped_cmd = if self.use_double_quotes {
-            shell_command.replace("\"", "\\\"")
-        } else {
-            shell_command.replace("'", "'\\''")
-        };
+        let escaped_cmd = shell_command.replace("'", "'\\''");
 
         let final_command = self.command_template.replace("{cmd}", &escaped_cmd);
         let display_command = self.display_template.replace("{cmd}", shell_command);
@@ -140,5 +124,22 @@ impl Toolchain {
 impl fmt::Display for Toolchain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_command_preserves_shell_expansion_characters_for_inner_shell() {
+        let (wrapped, _) = Toolchain::MISE.wrap_command("echo $HOME `whoami` \\path");
+        assert_eq!(wrapped, "mise exec -- sh -c 'echo $HOME `whoami` \\path'");
+    }
+
+    #[test]
+    fn wrap_command_escapes_single_quotes() {
+        let (wrapped, _) = Toolchain::MISE.wrap_command("echo don't");
+        assert_eq!(wrapped, "mise exec -- sh -c 'echo don'\\''t'");
     }
 }

--- a/mcproc/src/main.rs
+++ b/mcproc/src/main.rs
@@ -3,16 +3,40 @@ mod client;
 mod common;
 mod daemon;
 
+fn is_daemon_invocation(args: &[String]) -> bool {
+    args.get(1).is_some_and(|arg| arg == "--daemon")
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Check if --daemon flag is present in args
     let args: Vec<String> = std::env::args().collect();
 
-    if args.contains(&"--daemon".to_string()) {
+    if is_daemon_invocation(&args) {
         // Run in daemon mode
         daemon::run_daemon().await
     } else {
         // Run in CLI mode
         cli::run_cli().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_daemon_invocation;
+
+    #[test]
+    fn daemon_flag_is_only_recognized_as_first_argument() {
+        let direct = vec!["mcproc".to_string(), "--daemon".to_string()];
+        let command_argument = vec![
+            "mcproc".to_string(),
+            "start".to_string(),
+            "x".to_string(),
+            "--cmd".to_string(),
+            "--daemon".to_string(),
+        ];
+
+        assert!(is_daemon_invocation(&direct));
+        assert!(!is_daemon_invocation(&command_argument));
     }
 }


### PR DESCRIPTION
## Summary

Full source code review of mcproc (3 rounds) — fixes 37 bugs and vulnerabilities found across the daemon, CLI, and mcp-rs library. Round 3 re-reviewed the Round 1 & 2 fixes themselves for regressions and incomplete fixes.

All quality gates pass: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (mcp-rs: 4, mcproc lib: 44, mcproc bin: 45 passed).

## Round 1 fixes (16)

| Category | Fix | Files |
|---------|-----|-------|
| Data loss | batch_writer opened log files with truncate instead of append, so the stdout/stderr writers destroyed each other's data | `daemon/log/batch_writer.rs` |
| Backpressure | Replace hyperlog's unbounded_channel with a bounded channel(1024) | `daemon/process/hyperlog.rs` |
| Shell injection | POSIX single-quote escaping for args (`shell_quote_args`) | `daemon/process/launcher.rs` |
| Race condition | Atomic process-name reservation via RAII `ProcessNameReservation` | `daemon/process/manager.rs`, `registry.rs` |
| Incomplete stop | Poll `confirm_stopped_after_force_kill` after SIGKILL | `daemon/process/proxy.rs` |
| Path traversal | Validate process/project names in `grep_log_path` | `daemon/api/grpc/log_handlers.rs` |
| Encoding | Lossy UTF-8 reads (`read_until` + `from_utf8_lossy`) for streaming grep | `daemon/api/grpc/log_handlers.rs` |
| Memory | VecDeque-based streaming tail (no longer loads the whole file) | `daemon/api/grpc/log_handlers.rs` |
| Timezone | `parse_time_string` now interprets naive datetimes as Local | `daemon/api/grpc/log_handlers.rs` |
| Deadlock | MCP notification channel switched to unbounded_channel | `mcp-rs/src/server.rs` |
| Protocol compliance | JSON parse error responses, empty batch handling, jsonrpc version validation | `mcp-rs/src/protocol.rs`, `transport/stdio.rs` |
| Thread safety | Serialize stdio output with `Arc<Mutex<Stdout>>` | `mcp-rs/src/transport/stdio.rs` |
| Permissions | Apply `set_permissions(0o700)` to runtime/log dirs | `common/config/mod.rs` |
| First run | Create daemon_log_file parent dir in `ensure_directories` | `common/config/mod.rs`, `client/mod.rs` |
| Panic | Multibyte-safe truncation in `ps` command | `cli/commands/ps.rs` |
| Missing feature | Implement `ps --status` / gRPC `status_filter` | `cli/commands/ps.rs`, `daemon/api/grpc/process_handlers.rs` |

## Round 2 fixes (15)

| Category | Fix | Files |
|---------|-----|-------|
| Data loss | Flush final line without trailing newline at EOF | `daemon/process/hyperlog.rs` |
| Stop handling | Extend force-stop timeout 2s→5s, propagate stop errors | `daemon/process/manager.rs` |
| Name collision | Allow same process name across different projects | `daemon/process/manager.rs`, `registry.rs` |
| Name resolution | Registry prefers name lookup over UUID | `daemon/process/registry.rs` |
| Escaping consistency | Unify toolchain on single-quote escaping | `daemon/process/toolchain.rs` |
| Input validation | Upper bound (3600s) for `wait_timeout` | `daemon/api/grpc/process_handlers.rs` |
| Input validation | Reject unknown `status_filter` enum values | `daemon/api/grpc/process_handlers.rs` |
| Error propagation | Force-restart stop failures surface as `FailedPrecondition` | `daemon/api/grpc/process_handlers.rs` |
| Resource limits | Introduce MAX constants and clamp log line / context counts | `daemon/api/grpc/log_handlers.rs` |
| Robustness | Guard uptime calculation against clock rollback with `.max(0)` | `daemon/api/grpc/service.rs` |
| Performance | Shorten post-shutdown sleep 30s→500ms | `daemon/mod.rs` |
| Safety | Verify daemon PID (sysinfo) before SIGTERM/SIGKILL | `cli/commands/daemon.rs` |
| Data loss | Daemon log opened with append instead of truncate | `cli/commands/daemon.rs` |
| Overflow | Saturating arithmetic helpers for timeout calculations | `cli/utils.rs`, `start.rs`, `stop.rs`, `restart.rs` |
| Debug leftover | Remove `eprintln!("DEBUG:...")` from MCP start tool | `cli/commands/mcp/tools/start.rs` |

## Round 3 fixes (6) — regressions and incomplete fixes in Rounds 1 & 2

| Category | Fix | Files |
|---------|-----|-------|
| Resource limits | Cap grep results at `MAX_GREP_MATCHES` (1000); a match-everything pattern on a huge log could exhaust daemon memory despite the context clamp | `daemon/api/grpc/log_handlers.rs` |
| Data integrity | Insert a newline before appending when an existing log ends with a partial line (unclean shutdown), preventing joined records that break `parse_log_line` | `daemon/log/batch_writer.rs`, `cli/commands/daemon.rs` |
| Double daemon | A connectable socket now always counts as a running daemon; previously a stale PID file made `daemon start` spawn a second daemon that deleted and rebound the live socket | `cli/commands/daemon.rs` |
| Name resolution | UUID-shaped inputs prefer ID lookup; the Round 2 name-first change let a process named like another process's UUID hijack ID-based stop/restart | `daemon/process/registry.rs` |
| Permissions | Apply chmod 0700 only to directories mcproc newly creates; configured pre-existing dirs (e.g. a shared parent set as `socket_path`) are warned about, not modified | `common/config/mod.rs` |
| PID validation | Daemon PID check now requires the exact `mcproc` executable name plus a `--daemon` argument, instead of a substring match that also matched e.g. `vim mcproc/notes.md` or `mcproc ps` | `cli/commands/daemon.rs` |

Round 3 findings deferred with new issues (design changes needed):

- #46 MCP notifications are not drained while a tool call is executing (unbounded buffering, late delivery)
- #47 Daemon shutdown does not join log pipeline tasks; buffered logs can be lost

## Known issues not fixed here (tracked as issues)

Design decisions required — filed separately:

- #38 Reliably clean up descendant processes via process groups
- #39 `clean` command does not delete logs
- #40 Cannot fetch logs of stopped processes
- #41 Move blocking `lsof`/`pgrep` calls off the async runtime
- #42 hyperlog drops single lines larger than 1 MiB

Lower-priority findings from Round 2 left for follow-up: log growth without rotation (append mode), stderr_tail possibly mixing in previous runs, JSON parse error vs. invalid request distinction, partial batch failure handling, disk-write backpressure chain, version-check restart loop, missing MCP clean tool, silently ignored broadcast lag, `exit(0)` on Ctrl-C, numeric progress token typing, proto build.rs OUT_DIR, silently ignored unknown MCP parameters.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — mcp-rs: 4 passed / mcproc lib: 44 passed / mcproc bin: 45 passed (integration: 4 ignored, require installed binary)
