### PR TITLE
fix: resolve clippy 1.96 explicit_counter_loop in log_handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "mcproc"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "prost",
  "prost-types",

--- a/mcproc/src/daemon/api/grpc/log_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/log_handlers.rs
@@ -77,12 +77,12 @@ impl GrpcService {
                                     all_lines.push(line);
                                 }
 
-                                // Get tail lines
+                                // Get tail lines (line numbers are 1-based)
                                 let start_idx = all_lines.len().saturating_sub(tail);
-                                let mut line_num = start_idx as u32;
 
-                                for line in &all_lines[start_idx..] {
-                                    line_num += 1;
+                                for (line_num, line) in
+                                    (start_idx as u32 + 1..).zip(&all_lines[start_idx..])
+                                {
                                     let (timestamp, level, content) = parse_log_line(line);
 
                                     let log_entry = LogEntry {


### PR DESCRIPTION
## Description

Rewrites the manually incremented `line_num` counter loop in `mcproc/src/daemon/api/grpc/log_handlers.rs` to the `zip` form suggested by clippy 1.96's `explicit_counter_loop` lint (no `#[allow]`, per project policy). This lint was failing `cargo clippy --all-targets -- -D warnings` on main, breaking the mandatory pre-commit checklist for any change.

Also syncs `Cargo.lock` with the workspace version 0.1.4 (it was stale at 0.1.3; updated automatically by cargo during verification, committed separately).

**Reviewer note:** clippy's literal suggestion `(start_idx as u32..).zip(...)` would shift line numbers by one — the original code incremented `line_num` **before** use, so numbering is 1-based (`start_idx + 1 ..= len`). The range therefore starts at `start_idx as u32 + 1` to preserve the existing behavior.

Fixes #45
Closes #44 (duplicate of #45)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable — no behavior change)
- [x] My changes generate no new warnings (`cargo clippy --all-targets -- -D warnings` passes; failure reproduced before the fix)
- [ ] I have added tests that prove my fix is effective or that my feature works (lint-only refactor; verified by clippy itself)
- [x] New and existing unit tests pass locally with my changes (`cargo test`: 16 passed, 0 failed, 4 ignored)
- [ ] Any dependent changes have been merged and published (not applicable)
