### PR TITLE
fix(daemon): remove unconditional 30s sleep on daemon shutdown

### DIFF
--- a/mcproc/src/daemon/mod.rs
+++ b/mcproc/src/daemon/mod.rs
@@ -188,12 +188,6 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Give processes time to shut down gracefully
-    tokio::time::sleep(tokio::time::Duration::from_millis(
-        config.daemon.daemon_shutdown_timeout_ms,
-    ))
-    .await;
-
     // Remove PID file
     if let Err(e) = std::fs::remove_file(&config.paths.pid_file) {
         error!("Failed to remove PID file: {}", e);

--- a/mcproc/tests/daemon_shutdown_test.rs
+++ b/mcproc/tests/daemon_shutdown_test.rs
@@ -1,0 +1,83 @@
+//! Reproduces the bug where daemon shutdown unconditionally sleeps for
+//! daemon_shutdown_timeout_ms even when there are no managed processes.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+struct TestEnvironment {
+    base: PathBuf,
+}
+
+impl TestEnvironment {
+    fn new(base: PathBuf) -> Self {
+        Self { base }
+    }
+}
+
+impl Drop for TestEnvironment {
+    fn drop(&mut self) {
+        let pid_file = self.base.join("rt/mcproc/mcprocd.pid");
+        if let Ok(pid) = fs::read_to_string(pid_file) {
+            if let Ok(pid) = pid.trim().parse::<u32>() {
+                let _ = Command::new("kill").args(["-9", &pid.to_string()]).status();
+            }
+        }
+
+        let _ = fs::remove_dir_all(&self.base);
+    }
+}
+
+fn mcproc_command(base: &Path) -> Command {
+    let mut command = Command::new("mcproc");
+    command
+        .env("XDG_RUNTIME_DIR", base.join("rt"))
+        .env("XDG_STATE_HOME", base.join("state"))
+        .env("XDG_CONFIG_HOME", base.join("config"))
+        .env("XDG_DATA_HOME", base.join("data"));
+    command
+}
+
+#[test]
+#[ignore = "requires mcproc binary in PATH"]
+fn daemon_stop_with_no_processes_is_fast() {
+    // Keep this path short because macOS limits Unix socket paths to 104 bytes.
+    let base = PathBuf::from(format!("/tmp/mcproc-shdt-{}", std::process::id()));
+    let _environment = TestEnvironment::new(base.clone());
+
+    // "state/mcproc/log" is pre-created as a workaround for issue #37
+    // (daemon start fails when the state log directory is missing).
+    for directory in ["rt", "state/mcproc/log", "config", "data"] {
+        fs::create_dir_all(base.join(directory))
+            .unwrap_or_else(|error| panic!("failed to create {directory} directory: {error}"));
+    }
+
+    let start_output = mcproc_command(&base)
+        .args(["daemon", "start"])
+        .output()
+        .expect("failed to execute mcproc daemon start");
+    assert!(
+        start_output.status.success(),
+        "mcproc daemon start failed: {}",
+        String::from_utf8_lossy(&start_output.stderr)
+    );
+
+    let started_at = Instant::now();
+    let stop_output = mcproc_command(&base)
+        .args(["daemon", "stop"])
+        .output()
+        .expect("failed to execute mcproc daemon stop");
+    assert!(
+        stop_output.status.success(),
+        "mcproc daemon stop failed: {}",
+        String::from_utf8_lossy(&stop_output.stderr)
+    );
+    let elapsed = started_at.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "mcproc daemon stop took {:.3} seconds with no managed processes",
+        elapsed.as_secs_f64()
+    );
+}


### PR DESCRIPTION
## Description

`mcproc daemon stop` always took ~30 seconds, even with zero managed processes. The shutdown path in `mcproc/src/daemon/mod.rs` unconditionally slept for `daemon_shutdown_timeout_ms` (30s) after stopping managed processes. Process termination is already fully awaited by `ProcessManager::stop_process` (with SIGKILL escalation on timeout), so the sleep was redundant in all cases.

This PR removes the sleep and adds an integration test (`mcproc/tests/daemon_shutdown_test.rs`) that starts an isolated daemon (separate XDG dirs, short `/tmp` socket path for the macOS `SUN_LEN` limit) and asserts that `daemon stop` with no managed processes completes in under 5 seconds. The test was written first and failed against the unfixed code (30.069s observed), and passes after the fix (~0.5s).

Notes for reviewers:
- The test pre-creates `$XDG_STATE_HOME/mcproc/log` as a workaround for #37 (daemon start fails when the state log dir is missing).
- Manually verified that shutdown with a running managed process (`sleep 300`) still terminates the child correctly and completes in ~0.5s.
- `cargo clippy --all-targets -- -D warnings` currently fails on an unrelated pre-existing issue (#45, `explicit_counter_loop` in `log_handlers.rs` with clippy 1.96); the files touched here produce no warnings.
- The `Cargo.lock` diff is a legitimate sync to the workspace version 0.1.4.

Fixes #49

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes