### PR TITLE
fix(clean): delete project log files and report actual counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "mcproc"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1558,6 +1558,7 @@ dependencies = [
  "strip-ansi-escapes",
  "sysinfo",
  "tabled",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1911,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,9 +464,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytestring"
@@ -681,12 +681,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_more"
@@ -1643,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2418,12 +2415,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2433,15 +2429,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-stream"

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,10 @@ ignore = [
     # fxhash is a transitive dependency from jsonrpc-v2 -> extensions
     # No safe upgrade available as of now
     "RUSTSEC-2025-0057",
+    # proc-macro-error2 (unmaintained) is a transitive dependency from
+    # tabled -> tabled_derive; no safe upgrade available as of now
+    # (latest tabled_derive 0.11 still depends on it)
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]

--- a/mcproc/Cargo.toml
+++ b/mcproc/Cargo.toml
@@ -94,6 +94,7 @@ libc = "0.2"
 
 [dev-dependencies]
 serial_test = "3.2"
+tempfile = "3"
 
 # cargo-machete reports false positives for these dependencies
 # which are used through re-exports or feature flags

--- a/mcproc/src/daemon/api/grpc/log_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/log_handlers.rs
@@ -79,10 +79,10 @@ impl GrpcService {
 
                                 // Get tail lines
                                 let start_idx = all_lines.len().saturating_sub(tail);
-                                let mut line_num = start_idx as u32;
 
-                                for line in &all_lines[start_idx..] {
-                                    line_num += 1;
+                                for (line_num, line) in
+                                    (start_idx as u32 + 1..).zip(&all_lines[start_idx..])
+                                {
                                     let (timestamp, level, content) = parse_log_line(line);
 
                                     let log_entry = LogEntry {

--- a/mcproc/src/daemon/api/grpc/service.rs
+++ b/mcproc/src/daemon/api/grpc/service.rs
@@ -48,15 +48,18 @@ impl GrpcService {
 
             let project_results: Vec<_> = results
                 .into_iter()
-                .map(
-                    |(project, stopped_names)| proto::clean_project_response::ProjectCleanResult {
+                .map(|(project, (stopped_names, deleted_log_paths))| {
+                    proto::clean_project_response::ProjectCleanResult {
                         project,
                         processes_stopped: stopped_names.len() as u32,
-                        logs_deleted: 0,
+                        logs_deleted: deleted_log_paths.len() as u32,
                         stopped_process_names: stopped_names,
-                        deleted_log_files: vec![],
-                    },
-                )
+                        deleted_log_files: deleted_log_paths
+                            .into_iter()
+                            .map(|path| path.to_string_lossy().into_owned())
+                            .collect(),
+                    }
+                })
                 .collect();
 
             Ok(Response::new(CleanProjectResponse {
@@ -69,19 +72,24 @@ impl GrpcService {
         } else {
             // Clean single project
             let project = req.project.as_deref().unwrap_or("default");
-            let stopped_names = self
+            let (stopped_names, deleted_log_paths) = self
                 .process_manager
                 .clean_project(project, req.force)
                 .await
                 .map_err(|e| {
                     Status::internal(format!("Failed to clean project {}: {}", project, e))
                 })?;
+            let logs_deleted = deleted_log_paths.len() as u32;
+            let deleted_log_files = deleted_log_paths
+                .into_iter()
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect();
 
             Ok(Response::new(CleanProjectResponse {
                 processes_stopped: stopped_names.len() as u32,
-                logs_deleted: 0,
+                logs_deleted,
                 stopped_process_names: stopped_names,
-                deleted_log_files: vec![],
+                deleted_log_files,
                 project_results: vec![],
             }))
         }

--- a/mcproc/src/daemon/log/cleaner.rs
+++ b/mcproc/src/daemon/log/cleaner.rs
@@ -1,0 +1,161 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+/// Delete log files under a project's log directory.
+/// Files listed in `exclude` are kept (logs of processes still running).
+/// Returns the paths of files actually deleted.
+pub fn delete_project_logs(project_log_dir: &Path, exclude: &HashSet<PathBuf>) -> Vec<PathBuf> {
+    let entries = match fs::read_dir(project_log_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(error) => {
+            warn!(
+                path = %project_log_dir.display(),
+                %error,
+                "Failed to read project log directory"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut candidates = entries
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            let is_log_file = entry.file_type().is_ok_and(|file_type| file_type.is_file())
+                && path.extension().is_some_and(|extension| extension == "log");
+
+            (is_log_file && !exclude.contains(&path)).then_some(path)
+        })
+        .collect::<Vec<_>>();
+    candidates.sort();
+
+    let mut deleted = Vec::with_capacity(candidates.len());
+    for path in candidates {
+        match fs::remove_file(&path) {
+            Ok(()) => deleted.push(path),
+            Err(error) => warn!(
+                path = %path.display(),
+                %error,
+                "Failed to delete log file"
+            ),
+        }
+    }
+
+    let directory_is_empty =
+        fs::read_dir(project_log_dir).is_ok_and(|mut entries| entries.next().is_none());
+    if directory_is_empty {
+        let _ = fs::remove_dir(project_log_dir);
+    }
+
+    deleted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn deletes_all_log_files_and_returns_sorted_paths() {
+        let temp = tempdir().unwrap();
+        let project_dir = temp.path().join("project");
+        fs::create_dir(&project_dir).unwrap();
+        let second = project_dir.join("second.log");
+        let first = project_dir.join("first.log");
+        fs::write(&second, "second").unwrap();
+        fs::write(&first, "first").unwrap();
+
+        let deleted = delete_project_logs(&project_dir, &HashSet::new());
+
+        assert_eq!(deleted, vec![first.clone(), second.clone()]);
+        assert!(!first.exists());
+        assert!(!second.exists());
+    }
+
+    #[test]
+    fn keeps_excluded_log_file() {
+        let temp = tempdir().unwrap();
+        let project_dir = temp.path().join("project");
+        fs::create_dir(&project_dir).unwrap();
+        let deleted_log = project_dir.join("delete.log");
+        let excluded_log = project_dir.join("keep.log");
+        fs::write(&deleted_log, "delete").unwrap();
+        fs::write(&excluded_log, "keep").unwrap();
+        let exclude = HashSet::from([excluded_log.clone()]);
+
+        let deleted = delete_project_logs(&project_dir, &exclude);
+
+        assert_eq!(deleted, vec![deleted_log.clone()]);
+        assert!(!deleted_log.exists());
+        assert!(excluded_log.exists());
+    }
+
+    #[test]
+    fn returns_empty_for_missing_directory() {
+        let temp = tempdir().unwrap();
+        let missing = temp.path().join("missing");
+
+        let deleted = delete_project_logs(&missing, &HashSet::new());
+
+        assert!(deleted.is_empty());
+    }
+
+    #[test]
+    fn keeps_non_log_files() {
+        let temp = tempdir().unwrap();
+        let project_dir = temp.path().join("project");
+        fs::create_dir(&project_dir).unwrap();
+        let note = project_dir.join("note.txt");
+        fs::write(&note, "note").unwrap();
+
+        let deleted = delete_project_logs(&project_dir, &HashSet::new());
+
+        assert!(deleted.is_empty());
+        assert!(note.exists());
+    }
+
+    #[test]
+    fn keeps_subdirectories_and_their_contents() {
+        let temp = tempdir().unwrap();
+        let project_dir = temp.path().join("project");
+        let subdirectory = project_dir.join("sub");
+        fs::create_dir_all(&subdirectory).unwrap();
+        let inner_log = subdirectory.join("inner.log");
+        fs::write(&inner_log, "inner").unwrap();
+
+        let deleted = delete_project_logs(&project_dir, &HashSet::new());
+
+        assert!(deleted.is_empty());
+        assert!(subdirectory.exists());
+        assert!(inner_log.exists());
+    }
+
+    #[test]
+    fn removes_directory_after_deleting_all_files() {
+        let temp = tempdir().unwrap();
+        let project_dir = temp.path().join("project");
+        fs::create_dir(&project_dir).unwrap();
+        fs::write(project_dir.join("only.log"), "log").unwrap();
+
+        delete_project_logs(&project_dir, &HashSet::new());
+
+        assert!(!project_dir.exists());
+    }
+
+    #[test]
+    fn keeps_directory_when_excluded_file_remains() {
+        let temp = tempdir().unwrap();
+        let project_dir = temp.path().join("project");
+        fs::create_dir(&project_dir).unwrap();
+        let excluded_log = project_dir.join("keep.log");
+        fs::write(&excluded_log, "keep").unwrap();
+        let exclude = HashSet::from([excluded_log]);
+
+        delete_project_logs(&project_dir, &exclude);
+
+        assert!(project_dir.exists());
+    }
+}

--- a/mcproc/src/daemon/log/mod.rs
+++ b/mcproc/src/daemon/log/mod.rs
@@ -1,4 +1,5 @@
 pub mod batch_writer;
+pub mod cleaner;
 
 use crate::common::config::Config;
 use crate::common::process_key::ProcessKey;

--- a/mcproc/src/daemon/process/event.rs
+++ b/mcproc/src/daemon/process/event.rs
@@ -1,6 +1,3 @@
-use std::sync::Arc;
-use tokio::sync::broadcast;
-
 /// Events related to process lifecycle
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -74,39 +71,3 @@ impl ProcessEvent {
         }
     }
 }
-
-/// Event bus for process lifecycle events
-#[allow(dead_code)]
-pub struct ProcessEventBus {
-    sender: broadcast::Sender<ProcessEvent>,
-}
-
-impl ProcessEventBus {
-    pub fn new() -> Self {
-        let (sender, _) = broadcast::channel(1000);
-        Self { sender }
-    }
-
-    /// Publish an event to all subscribers
-    #[allow(dead_code)]
-    pub fn publish(&self, event: ProcessEvent) {
-        // Ignore send errors (no receivers)
-        let _ = self.sender.send(event);
-    }
-
-    /// Subscribe to process events
-    #[allow(dead_code)]
-    pub fn subscribe(&self) -> broadcast::Receiver<ProcessEvent> {
-        self.sender.subscribe()
-    }
-}
-
-impl Default for ProcessEventBus {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Shared event bus instance
-#[allow(dead_code)]
-pub type SharedEventBus = Arc<ProcessEventBus>;

--- a/mcproc/src/daemon/process/manager.rs
+++ b/mcproc/src/daemon/process/manager.rs
@@ -1,7 +1,7 @@
 use crate::common::config::Config;
 use crate::common::process_key::ProcessKey;
 use crate::daemon::error::{McprocdError, Result};
-use crate::daemon::log::LogHub;
+use crate::daemon::log::{cleaner, LogHub};
 use crate::daemon::process::exit_handler::ExitHandler;
 use crate::daemon::process::launcher::ProcessLauncher;
 use crate::daemon::process::log_stream::LogStreamConfig;
@@ -10,7 +10,7 @@ use crate::daemon::process::proxy::{ProcessStatus, ProxyInfo};
 use crate::daemon::process::registry::ProcessRegistry;
 use crate::daemon::stream::{SharedStreamEventHub, StreamEvent};
 use colored::Colorize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -603,7 +603,11 @@ impl ProcessManager {
         processes
     }
 
-    pub async fn clean_project(&self, project: &str, force: bool) -> Result<Vec<String>> {
+    pub async fn clean_project(
+        &self,
+        project: &str,
+        force: bool,
+    ) -> Result<(Vec<String>, Vec<PathBuf>)> {
         let processes = self.registry.get_processes_by_project(project);
         let mut stopped = Vec::new();
 
@@ -619,17 +623,47 @@ impl ProcessManager {
             }
         }
 
-        Ok(stopped)
+        let exclude = self
+            .registry
+            .get_processes_by_project(project)
+            .into_iter()
+            .map(|process| {
+                let key = ProcessKey::new(process.project.clone(), process.name.clone());
+                self.log_hub.get_log_file_path_for_key(&key)
+            })
+            .collect::<HashSet<_>>();
+        let project_log_dir = self.config.paths.log_dir.join(project);
+        let deleted_logs = cleaner::delete_project_logs(&project_log_dir, &exclude);
+
+        Ok((stopped, deleted_logs))
     }
 
-    pub async fn clean_all_projects(&self, force: bool) -> Result<HashMap<String, Vec<String>>> {
-        let projects = self.registry.get_all_projects();
+    pub async fn clean_all_projects(
+        &self,
+        force: bool,
+    ) -> Result<HashMap<String, (Vec<String>, Vec<PathBuf>)>> {
+        let mut projects = self
+            .registry
+            .get_all_projects()
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        if let Ok(entries) = std::fs::read_dir(&self.config.paths.log_dir) {
+            for entry in entries.flatten() {
+                if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+                    projects.insert(entry.file_name().to_string_lossy().into_owned());
+                }
+            }
+        }
+
+        let mut projects = projects.into_iter().collect::<Vec<_>>();
+        projects.sort();
         let mut results = HashMap::new();
 
         for project in projects {
             match self.clean_project(&project, force).await {
-                Ok(stopped) => {
-                    results.insert(project, stopped);
+                Ok(result) => {
+                    results.insert(project, result);
                 }
                 Err(e) => {
                     error!("Failed to clean project {}: {}", project, e);


### PR DESCRIPTION
## Description

`mcproc clean` is documented as stopping processes and cleaning logs, but `clean_project_impl` never deleted any log files and always returned `logs_deleted: 0` in both single-project and all-projects mode.

This PR implements actual log deletion:

- **New `daemon/log/cleaner.rs`**: core deletion as a pure function — removes regular `.log` files directly under a project's log directory (non-recursive), keeps files listed in an exclude set, warns and skips on per-file failures, and removes the directory once it becomes empty.
- **`ProcessManager::clean_project`**: after stopping processes, deletes the project's logs while excluding logs of processes still running (i.e. those that failed to stop), and returns the deleted paths alongside stopped process names.
- **`ProcessManager::clean_all_projects`**: sweeps the union of registry projects and directories under the log root, so projects that only have leftover logs (no registered processes) are cleaned too.
- **`clean_project_impl`**: populates `logs_deleted` / `deleted_log_files` from real results. No proto/CLI/MCP interface changes.
- **`log_handlers.rs`**: rewrote the tail loop with `zip` because clippy 1.96 now fails the mandatory `-D warnings` gate with `explicit_counter_loop` on the old code (line numbering is unchanged).

Fixes #39

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Verification

Test-first (Red→Green): the 7 cleaner unit tests were written against a stub first (3 deletion tests failed as expected), then the implementation turned them green. `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --all-targets`, and `cargo test` (lib 15 passed, bin 15 passed) all pass.

E2E with the built binary in an isolated XDG environment:

- Single project: `Cleaned project e2e-clean: 2 processes stopped, 2 logs deleted`, deleted file paths listed with `-v`, project log directory removed, and a second `clean` reports `No processes or logs found`.
- `--all-projects`: a project with only leftover logs is reported as `0 processes stopped, 1 logs deleted`, and the summary totals match.