### PR TITLE
fix(deps): bump anyhow/bytes/time to resolve cargo deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "mcproc"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1556,7 +1556,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "strip-ansi-escapes",
- "sysinfo",
  "tabled",
  "thiserror",
  "tokio",
@@ -1623,15 +1622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,25 +1653,6 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1911,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "prost",
  "prost-types",
@@ -2324,20 +2295,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe840c5b1afe259a5657392a4dbb74473a14c8db999c3ec2f4ae812e028a94da"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
 ]
 
 [[package]]
@@ -2958,27 +2915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,17 +2925,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -3029,16 +2954,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-result"
@@ -3116,15 +3031,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-stream"
@@ -464,9 +464,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytestring"
@@ -681,12 +681,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_more"
@@ -1632,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2374,12 +2371,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2389,15 +2385,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,9 @@ ignore = [
     # fxhash is a transitive dependency from jsonrpc-v2 -> extensions
     # No safe upgrade available as of now
     "RUSTSEC-2025-0057",
+    # proc-macro-error2 (unmaintained) is a transitive dependency from
+    # tabled -> tabled_derive; no tabled release without it as of now
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]

--- a/mcproc/Cargo.toml
+++ b/mcproc/Cargo.toml
@@ -81,9 +81,6 @@ strip-ansi-escapes = "0.2.1"
 crossbeam-channel.workspace = true
 bytes.workspace = true
 
-# Process info
-sysinfo = "0.38"
-
 # File locking
 fs2 = "0.4"
 

--- a/mcproc/src/daemon/process/launcher.rs
+++ b/mcproc/src/daemon/process/launcher.rs
@@ -136,28 +136,36 @@ impl ProcessLauncher {
         command.stdin(Stdio::null());
 
         // IMPORTANT: Do NOT use kill_on_drop(true) as it sends SIGKILL immediately
-        // and prevents graceful shutdown. We handle process termination manually
-        // in ProxyInfo::stop() with proper SIGTERM -> wait -> SIGKILL sequence.
+        // and prevents graceful shutdown. ProxyInfo::stop() signals the process group
+        // with the proper SIGTERM -> wait -> SIGKILL sequence.
         command.kill_on_drop(false);
 
-        // Set up process death signal on Linux
-        // This ensures child processes receive SIGTERM when the parent dies
-        #[cfg(target_os = "linux")]
+        // Create a dedicated session so the child PID is also the process group ID.
+        // ProxyInfo::stop() relies on this invariant to signal the entire process tree.
+        #[cfg(unix)]
         {
             unsafe {
                 command.pre_exec(|| {
-                    // PR_SET_PDEATHSIG = 1
-                    let result = libc::prctl(1, libc::SIGTERM);
-                    if result == -1 {
-                        eprintln!(
-                            "prctl(PR_SET_PDEATHSIG) failed with errno: {}",
-                            std::io::Error::last_os_error()
-                        );
+                    if libc::setsid() == -1 {
+                        return Err(std::io::Error::last_os_error());
                     }
+
+                    #[cfg(target_os = "linux")]
+                    {
+                        // PR_SET_PDEATHSIG = 1
+                        let result = libc::prctl(1, libc::SIGTERM);
+                        if result == -1 {
+                            eprintln!(
+                                "prctl(PR_SET_PDEATHSIG) failed with errno: {}",
+                                std::io::Error::last_os_error()
+                            );
+                        }
+                    }
+
                     Ok(())
                 });
             }
-            debug!("Configured PR_SET_PDEATHSIG for {}", params.name);
+            debug!("Configured dedicated process group for {}", params.name);
         }
 
         // Log file will be created automatically on first write

--- a/mcproc/src/daemon/process/proxy.rs
+++ b/mcproc/src/daemon/process/proxy.rs
@@ -4,13 +4,12 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
-use sysinfo::{Pid as SysPid, ProcessesToUpdate, System};
 use tokio::task::JoinHandle;
 use tracing::info;
 
 #[cfg(unix)]
 use nix::{
-    sys::signal::{self, Signal},
+    sys::signal::{killpg, Signal},
     unistd::Pid,
 };
 
@@ -148,39 +147,27 @@ impl ProxyInfo {
         );
         self.set_status(ProcessStatus::Stopping);
 
-        // NOTE: We do NOT cancel tasks here anymore. Cancelling the monitor task
+        // NOTE: We do NOT cancel tasks here. Cancelling the monitor task
         // would drop the Child object, closing stdout/stderr pipes and causing
-        // the child to receive SIGPIPE instead of our SIGTERM signal.
-
-        // Find all child processes of this PID
-        let child_pids = self.find_child_processes(self.pid).await;
-        if !child_pids.is_empty() {
-            info!(
-                "Found {} child process(es) for {} (PID: {}): {:?}",
-                child_pids.len(),
-                self.name,
-                self.pid,
-                child_pids
-            );
-        }
+        // group members to receive SIGPIPE instead of our group signal.
 
         // First attempt: Send SIGTERM (unless force is specified)
         if !force {
             info!(
-                "Sending SIGTERM to process {} (PID: {})",
+                "Sending SIGTERM to process group {} (PGID: {})",
                 self.name, self.pid
             );
 
             #[cfg(unix)]
             {
-                match Self::send_signal(self.pid, Signal::SIGTERM) {
+                match Self::send_signal_to_group(self.pid, Signal::SIGTERM) {
                     Ok(()) => {
-                        info!("SIGTERM sent successfully to PID {}", self.pid);
+                        info!("SIGTERM sent successfully to PGID {}", self.pid);
                     }
                     Err(e) => {
-                        info!("Failed to send SIGTERM to PID {}: {}", self.pid, e);
-                        // If process doesn't exist, mark as stopped
-                        if !Self::is_process_alive(self.pid) {
+                        info!("Failed to send SIGTERM to PGID {}: {}", self.pid, e);
+                        // If the process group doesn't exist, mark as stopped
+                        if !Self::is_process_group_alive(self.pid) {
                             self.set_status(ProcessStatus::Stopped);
                             if let Ok(mut exit_time) = self.exit_time.lock() {
                                 *exit_time = Some(Utc::now());
@@ -188,11 +175,6 @@ impl ProxyInfo {
                             return Ok(());
                         }
                     }
-                }
-
-                // Also send SIGTERM to all child processes directly
-                for child_pid in &child_pids {
-                    let _ = Self::send_signal(*child_pid, Signal::SIGTERM);
                 }
             }
 
@@ -203,10 +185,9 @@ impl ProxyInfo {
             #[cfg(unix)]
             {
                 while start.elapsed() < timeout {
-                    // Check if process is still alive
-                    if !Self::is_process_alive(self.pid) {
-                        info!("Process {} has stopped", self.name);
-                        // Process has stopped
+                    // The group is stopped only after every member has exited.
+                    if !Self::is_process_group_alive(self.pid) {
+                        info!("Process group {} has stopped", self.name);
                         self.set_status(ProcessStatus::Stopped);
                         if let Ok(mut exit_time) = self.exit_time.lock() {
                             *exit_time = Some(Utc::now());
@@ -222,33 +203,21 @@ impl ProxyInfo {
         }
 
         // Force kill with SIGKILL
-        info!("Sending SIGKILL to process {}", self.name);
+        info!("Sending SIGKILL to process group {}", self.name);
 
         #[cfg(unix)]
         {
-            match Self::send_signal(self.pid, Signal::SIGKILL) {
+            match Self::send_signal_to_group(self.pid, Signal::SIGKILL) {
                 Ok(()) => {
-                    info!("SIGKILL sent successfully to PID {}", self.pid);
+                    info!("SIGKILL sent successfully to PGID {}", self.pid);
                 }
                 Err(e) => {
-                    info!("Failed to send SIGKILL to PID {}: {}", self.pid, e);
-                    // If process doesn't exist, that's OK
-                    if !Self::is_process_alive(self.pid) {
-                        info!("Process {} already terminated", self.name);
-                    } else {
-                        // Process still exists but we couldn't kill it
-                        // Try to kill child processes directly
-                        info!("Killing child processes directly");
-                        for child_pid in &child_pids {
-                            let _ = Self::send_signal(*child_pid, Signal::SIGKILL);
-                        }
+                    info!("Failed to send SIGKILL to PGID {}: {}", self.pid, e);
+                    // If the process group doesn't exist, that's OK
+                    if !Self::is_process_group_alive(self.pid) {
+                        info!("Process group {} already terminated", self.name);
                     }
                 }
-            }
-
-            // Also kill all child processes to ensure cleanup
-            for child_pid in &child_pids {
-                let _ = Self::send_signal(*child_pid, Signal::SIGKILL);
             }
         }
 
@@ -272,51 +241,26 @@ impl ProxyInfo {
         }
     }
 
-    /// Send a signal to a process using nix crate
+    /// Send a signal to every process in the managed process group.
     #[cfg(unix)]
-    fn send_signal(pid: u32, sig: Signal) -> Result<(), String> {
-        match signal::kill(Pid::from_raw(pid as i32), sig) {
+    fn send_signal_to_group(pgid: u32, sig: Signal) -> Result<(), String> {
+        match killpg(Pid::from_raw(pgid as i32), sig) {
             Ok(()) => Ok(()),
             Err(nix::Error::ESRCH) => {
-                // Process doesn't exist - this is OK
+                // The process group has already exited.
                 Ok(())
             }
-            Err(e) => Err(format!("Failed to send signal: {}", e)),
+            Err(e) => Err(format!("Failed to send process group signal: {}", e)),
         }
     }
 
-    /// Check if a process is alive using nix crate
+    /// Check whether any process remains in the managed process group.
     #[cfg(unix)]
-    fn is_process_alive(pid: u32) -> bool {
-        // Send signal 0 to check if process exists
-        match signal::kill(Pid::from_raw(pid as i32), None) {
+    fn is_process_group_alive(pgid: u32) -> bool {
+        match killpg(Pid::from_raw(pgid as i32), None) {
             Ok(()) => true,
             Err(nix::Error::ESRCH) => false,
-            Err(_) => true, // Other errors mean process exists but we may lack permissions
+            Err(_) => true, // Other errors mean the group exists but we may lack permissions
         }
-    }
-
-    /// Find all child processes of a given PID using sysinfo
-    async fn find_child_processes(&self, parent_pid: u32) -> Vec<u32> {
-        let mut system = System::new_all();
-        system.refresh_processes(ProcessesToUpdate::All, true);
-
-        let mut child_pids = Vec::new();
-        let parent_pid = SysPid::from(parent_pid as usize);
-
-        // Helper function to recursively find all descendants
-        fn find_descendants(system: &System, parent_pid: SysPid, result: &mut Vec<u32>) {
-            for (pid, process) in system.processes() {
-                if process.parent() == Some(parent_pid) {
-                    let child_pid = pid.as_u32();
-                    result.push(child_pid);
-                    // Recursively find children of this child
-                    find_descendants(system, *pid, result);
-                }
-            }
-        }
-
-        find_descendants(&system, parent_pid, &mut child_pids);
-        child_pids
     }
 }

--- a/mcproc/tests/process_group_test.rs
+++ b/mcproc/tests/process_group_test.rs
@@ -1,0 +1,177 @@
+#![cfg(unix)]
+
+use mcproc::daemon::process::launcher::{
+    CreateProxyInfoParams, LaunchProcessParams, ProcessLauncher,
+};
+use nix::errno::Errno;
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::{getpgid, Pid};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::time::{sleep, timeout, Instant};
+
+struct ProcessCleanup {
+    pids: Vec<Pid>,
+}
+
+impl ProcessCleanup {
+    fn new(pid: Pid) -> Self {
+        Self { pids: vec![pid] }
+    }
+
+    fn add(&mut self, pid: Pid) {
+        self.pids.push(pid);
+    }
+
+    fn remove(&mut self, pid: Pid) {
+        self.pids.retain(|candidate| *candidate != pid);
+    }
+}
+
+impl Drop for ProcessCleanup {
+    fn drop(&mut self) {
+        for pid in &self.pids {
+            let _ = kill(*pid, Signal::SIGKILL);
+        }
+    }
+}
+
+fn launch_params(name: &str, project: &str, cmd: &str) -> LaunchProcessParams {
+    LaunchProcessParams {
+        name: name.to_string(),
+        project: project.to_string(),
+        cmd: Some(cmd.to_string()),
+        args: Vec::new(),
+        cwd: None,
+        env: None,
+        toolchain: None,
+    }
+}
+
+fn child_pid(child: &tokio::process::Child) -> Pid {
+    let pid = child.id().expect("spawned process should have a PID");
+    Pid::from_raw(i32::try_from(pid).expect("child PID should fit in i32"))
+}
+
+#[tokio::test]
+async fn test_spawned_process_gets_own_process_group() {
+    let launcher = ProcessLauncher::new();
+    let test_id = std::process::id();
+    let (mut child, _) = launcher
+        .launch_process(launch_params(
+            &format!("process-group-leader-{test_id}"),
+            &format!("process-group-test-{test_id}"),
+            "sleep 30",
+        ))
+        .await
+        .expect("failed to launch sleep process");
+
+    let pid = child_pid(&child);
+    let mut cleanup = ProcessCleanup::new(pid);
+    let child_pgid = getpgid(Some(pid)).expect("failed to get child process group");
+    let test_pgid = getpgid(None).expect("failed to get test process group");
+
+    // Capture process-group values before cleanup so assertions test the launch state.
+    let _ = kill(pid, Signal::SIGKILL);
+    if timeout(Duration::from_secs(1), child.wait()).await.is_ok() {
+        cleanup.remove(pid);
+    }
+
+    assert_ne!(
+        child_pgid, test_pgid,
+        "spawned process should not share the test process group"
+    );
+    assert_eq!(
+        child_pgid, pid,
+        "spawned process should be its process-group leader"
+    );
+}
+
+#[tokio::test]
+async fn test_stop_kills_orphaned_grandchild() {
+    const COMMAND: &str = r#"(sleep 300 & echo "GRANDCHILD_PID=$!"); sleep 300"#;
+
+    let launcher = ProcessLauncher::new();
+    let test_id = std::process::id();
+    let name = format!("orphan-grandchild-{test_id}");
+    let project = format!("orphan-grandchild-test-{test_id}");
+    let (mut child, _) = launcher
+        .launch_process(launch_params(&name, &project, COMMAND))
+        .await
+        .expect("failed to launch orphan-grandchild command");
+
+    let pid = child_pid(&child);
+    let mut cleanup = ProcessCleanup::new(pid);
+    let stdout = child.stdout.take().expect("child stdout should be piped");
+    let mut lines = BufReader::new(stdout).lines();
+
+    let grandchild_pid = timeout(Duration::from_secs(5), async {
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if let Some(raw_pid) = line.strip_prefix("GRANDCHILD_PID=") {
+                        let parsed = raw_pid
+                            .trim()
+                            .parse::<i32>()
+                            .expect("grandchild PID should be an integer");
+                        break Pid::from_raw(parsed);
+                    }
+                }
+                Ok(None) => panic!("child stdout closed before reporting grandchild PID"),
+                Err(error) => panic!("failed to read child stdout: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for grandchild PID");
+    cleanup.add(grandchild_pid);
+
+    assert_eq!(
+        kill(grandchild_pid, None),
+        Ok(()),
+        "grandchild should be alive before stop"
+    );
+
+    let proxy = launcher.create_proxy_info(CreateProxyInfoParams {
+        name,
+        project,
+        cmd: Some(COMMAND.to_string()),
+        args: Vec::new(),
+        cwd: None,
+        env: None,
+        wait_for_log: None,
+        wait_timeout: None,
+        toolchain: None,
+        pid: u32::try_from(pid.as_raw()).expect("child PID should be positive"),
+    });
+
+    proxy
+        .stop(false, 2_000)
+        .await
+        .expect("failed to stop process");
+
+    if timeout(Duration::from_secs(1), child.wait()).await.is_ok() {
+        cleanup.remove(pid);
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let grandchild_exited = loop {
+        match kill(grandchild_pid, None) {
+            Err(Errno::ESRCH) => break true,
+            _ if Instant::now() >= deadline => break false,
+            _ => sleep(Duration::from_millis(50)).await,
+        }
+    };
+
+    if grandchild_exited {
+        cleanup.remove(grandchild_pid);
+    } else {
+        // Ensure the Red test cannot leave the orphaned process running.
+        let _ = kill(grandchild_pid, Signal::SIGKILL);
+    }
+
+    assert!(
+        grandchild_exited,
+        "stop should terminate the orphaned grandchild process"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the CI Security & License check (`cargo deny`) failure on main (Closes #55).

- **anyhow** 1.0.100 → 1.0.103 — RUSTSEC-2026-0190 (`Error::downcast_mut()` unsoundness), patched in >= 1.0.103
- **bytes** 1.11.0 → 1.12.1 — RUSTSEC-2026-0007 (`BytesMut::reserve` integer overflow), patched in >= 1.11.1
- **time** 0.3.46 → 0.3.53 — RUSTSEC-2026-0009 (RFC 2822 parsing stack exhaustion DoS), patched in >= 0.3.47; detected by the latest advisory DB, would fail CI next run
- **deny.toml**: ignore RUSTSEC-2026-0173 (`proc-macro-error2` unmaintained) — transitive via `tabled` → `tabled_derive`; even the latest tabled 0.21.0 still depends on it, so no upgrade path exists yet (same pattern as the existing fxhash ignore)

Note: Dependabot PR #33 bumps anyhow only to 1.0.102, which does **not** reach the patched version (>= 1.0.103), so merging it would not resolve the advisory.

## Verification

Ran locally with cargo-deny 0.18:

- `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok
- `cargo build --all-targets` → success
- `cargo test` → 18 passed, 0 failed (4 ignored: integration tests requiring an isolated daemon)
- `cargo fmt -- --check` → clean

Known pre-existing CI failures unrelated to this PR: Lint fails on main due to `explicit_counter_loop` / dead_code (Issues #44 / #54, fix pending in PR #50).