### PR TITLE
fix: resolve review follow-ups — stopped-process logs, async port detection, MCP notification draining, shutdown log flush

### DIFF
--- a/mcp-rs/src/server.rs
+++ b/mcp-rs/src/server.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::notification::NotificationSender;
 use crate::protocol::{Protocol, ToolHandler};
 use crate::transport::Transport;
@@ -9,16 +9,26 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 use tracing::{debug, info};
+
+const OUTGOING_CHANNEL_CAPACITY: usize = 1024;
 
 /// Real-time notification sender that sends notifications immediately
 struct RealtimeNotificationSender {
-    tx: mpsc::UnboundedSender<JsonRpcNotification>,
+    tx: mpsc::Sender<JsonRpcMessage>,
 }
 
 impl RealtimeNotificationSender {
-    fn new(tx: mpsc::UnboundedSender<JsonRpcNotification>) -> Self {
+    fn new(tx: mpsc::Sender<JsonRpcMessage>) -> Self {
         Self { tx }
+    }
+
+    async fn send_notification(&self, notification: JsonRpcNotification) -> Result<()> {
+        self.tx
+            .send(JsonRpcMessage::Notification(notification))
+            .await
+            .map_err(|_| Error::Internal("Failed to send notification".to_string()))
     }
 }
 
@@ -31,10 +41,7 @@ impl NotificationSender for RealtimeNotificationSender {
             params: Some(serde_json::to_value(notification)?),
         };
 
-        self.tx.send(notif).map_err(|_| {
-            crate::error::Error::Internal("Failed to send notification".to_string())
-        })?;
-        Ok(())
+        self.send_notification(notif).await
     }
 
     async fn send_progress(&self, notification: ProgressNotification) -> Result<()> {
@@ -44,10 +51,7 @@ impl NotificationSender for RealtimeNotificationSender {
             params: Some(serde_json::to_value(notification)?),
         };
 
-        self.tx.send(notif).map_err(|_| {
-            crate::error::Error::Internal("Failed to send notification".to_string())
-        })?;
-        Ok(())
+        self.send_notification(notif).await
     }
 
     async fn send_raw(&self, method: String, params: Option<Value>) -> Result<()> {
@@ -57,10 +61,7 @@ impl NotificationSender for RealtimeNotificationSender {
             params,
         };
 
-        self.tx.send(notif).map_err(|_| {
-            crate::error::Error::Internal("Failed to send notification".to_string())
-        })?;
-        Ok(())
+        self.send_notification(notif).await
     }
 }
 
@@ -86,13 +87,16 @@ impl Server {
         // Start transport
         self.transport.start().await?;
 
-        // Create notification channel
-        let (notification_tx, mut notification_rx) =
-            mpsc::unbounded_channel::<JsonRpcNotification>();
+        // Use one bounded queue for notifications and responses so backpressure and ordering
+        // are preserved while handlers run independently from transport I/O.
+        let (outgoing_tx, mut outgoing_rx) =
+            mpsc::channel::<JsonRpcMessage>(OUTGOING_CHANNEL_CAPACITY);
 
         // Create real-time notification sender
-        let realtime_sender = Arc::new(RealtimeNotificationSender::new(notification_tx.clone()));
+        let realtime_sender = Arc::new(RealtimeNotificationSender::new(outgoing_tx.clone()));
         self.protocol.set_notification_sender(realtime_sender).await;
+
+        let mut handler_tasks: JoinSet<Result<()>> = JoinSet::new();
 
         // Main message loop
         loop {
@@ -103,25 +107,50 @@ impl Server {
                         Some(message) => {
                             debug!("Received message: {:?}", message);
 
-                            // Handle message and get response
-                            let response = self.protocol.handle_message_realtime(message).await;
-
-                            // Send the response if any
-                            if let Some(response) = response {
-                                debug!("Sending response: {:?}", response);
-                                self.transport.send(response).await?;
-                            }
+                            let protocol = self.protocol.clone();
+                            let response_tx = outgoing_tx.clone();
+                            handler_tasks.spawn(async move {
+                                if let Some(response) = protocol.handle_message_realtime(message).await {
+                                    response_tx.send(response).await.map_err(|_| {
+                                        Error::Internal("Failed to send response".to_string())
+                                    })?;
+                                }
+                                Ok(())
+                            });
                         }
                         None => {
-                            info!("Transport closed, shutting down server");
+                            info!("Transport closed, draining server work");
                             break;
                         }
                     }
                 }
-                // Handle notifications
-                Some(notification) = notification_rx.recv() => {
-                    debug!("Sending notification: {:?}", notification);
-                    self.transport.send(JsonRpcMessage::Notification(notification)).await?;
+                Some(message) = outgoing_rx.recv() => {
+                    debug!("Sending message: {:?}", message);
+                    self.transport.send(message).await?;
+                }
+                task_result = handler_tasks.join_next(), if !handler_tasks.is_empty() => {
+                    if let Some(task_result) = task_result {
+                        task_result
+                            .map_err(|error| Error::Internal(format!("Message handler task failed: {error}")))??;
+                    }
+                }
+            }
+        }
+
+        // A handler may be blocked on the bounded queue when receive returns None. Keep
+        // draining messages while joining every task, then flush anything queued by the last
+        // completed task before closing the transport.
+        while !handler_tasks.is_empty() || !outgoing_rx.is_empty() {
+            tokio::select! {
+                Some(message) = outgoing_rx.recv() => {
+                    debug!("Sending message during shutdown: {:?}", message);
+                    self.transport.send(message).await?;
+                }
+                task_result = handler_tasks.join_next(), if !handler_tasks.is_empty() => {
+                    if let Some(task_result) = task_result {
+                        task_result
+                            .map_err(|error| Error::Internal(format!("Message handler task failed: {error}")))??;
+                    }
                 }
             }
         }
@@ -175,9 +204,11 @@ mod tests {
     use crate::types::{JsonRpcId, JsonRpcRequest, MessageLevel, ToolInfo};
     use serde_json::json;
     use std::collections::VecDeque;
+    use std::sync::Mutex;
 
     struct MockTransport {
         incoming: VecDeque<JsonRpcMessage>,
+        sent: Arc<Mutex<Vec<JsonRpcMessage>>>,
     }
 
     #[async_trait]
@@ -186,7 +217,8 @@ mod tests {
             Ok(())
         }
 
-        async fn send(&mut self, _message: JsonRpcMessage) -> Result<()> {
+        async fn send(&mut self, message: JsonRpcMessage) -> Result<()> {
+            self.sent.lock().unwrap().push(message);
             Ok(())
         }
 
@@ -199,7 +231,9 @@ mod tests {
         }
     }
 
-    struct NoisyTool;
+    struct NoisyTool {
+        notification_count: usize,
+    }
 
     #[async_trait]
     impl ToolHandler for NoisyTool {
@@ -216,7 +250,7 @@ mod tests {
             _params: Option<Value>,
             context: crate::notification::ToolContext,
         ) -> Result<Value> {
-            for index in 0..150 {
+            for index in 0..self.notification_count {
                 context
                     .send_log(MessageLevel::Info, format!("notification {index}"))
                     .await?;
@@ -227,16 +261,15 @@ mod tests {
 
     #[tokio::test]
     async fn tool_call_with_more_than_channel_capacity_does_not_deadlock() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
         let transport = MockTransport {
-            incoming: VecDeque::from([JsonRpcMessage::Request(JsonRpcRequest {
-                jsonrpc: "2.0".to_string(),
-                method: "tools/call".to_string(),
-                params: Some(json!({"name": "noisy", "arguments": {}})),
-                id: JsonRpcId::Number(1),
-            })]),
+            incoming: VecDeque::from([tool_call_request()]),
+            sent,
         };
         let mut server = ServerBuilder::new("test", "1")
-            .add_tool(Arc::new(NoisyTool))
+            .add_tool(Arc::new(NoisyTool {
+                notification_count: 150,
+            }))
             .build(Box::new(transport))
             .await
             .unwrap();
@@ -245,5 +278,77 @@ mod tests {
             .await
             .expect("server deadlocked while tool sent notifications")
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn notifications_are_sent_before_tool_response() {
+        let sent = run_noisy_tool(150).await;
+        let messages = sent.lock().unwrap();
+
+        assert!(
+            matches!(messages.first(), Some(JsonRpcMessage::Notification(_))),
+            "the first outgoing message should be a notification, got {messages:?}"
+        );
+        assert_eq!(messages.len(), 151, "all notifications and the response");
+
+        let response_index = messages
+            .iter()
+            .position(|message| matches!(message, JsonRpcMessage::Response(_)))
+            .expect("tool response was not sent");
+        assert!(
+            messages[..response_index]
+                .iter()
+                .all(|message| matches!(message, JsonRpcMessage::Notification(_))),
+            "all tool notifications should precede its response"
+        );
+        assert_eq!(response_index, 150);
+    }
+
+    #[tokio::test]
+    async fn tool_call_exceeding_outgoing_channel_capacity_sends_every_message() {
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), run_noisy_tool(1_500))
+            .await
+            .expect("server deadlocked when the outgoing channel reached capacity");
+        let messages = sent.lock().unwrap();
+
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| matches!(message, JsonRpcMessage::Notification(_)))
+                .count(),
+            1_500
+        );
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| matches!(message, JsonRpcMessage::Response(_)))
+                .count(),
+            1
+        );
+    }
+
+    fn tool_call_request() -> JsonRpcMessage {
+        JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "tools/call".to_string(),
+            params: Some(json!({"name": "noisy", "arguments": {}})),
+            id: JsonRpcId::Number(1),
+        })
+    }
+
+    async fn run_noisy_tool(notification_count: usize) -> Arc<Mutex<Vec<JsonRpcMessage>>> {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = MockTransport {
+            incoming: VecDeque::from([tool_call_request()]),
+            sent: sent.clone(),
+        };
+        let mut server = ServerBuilder::new("test", "1")
+            .add_tool(Arc::new(NoisyTool { notification_count }))
+            .build(Box::new(transport))
+            .await
+            .unwrap();
+
+        server.start().await.unwrap();
+        sent
     }
 }

--- a/mcproc/src/daemon/api/grpc/log_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/log_handlers.rs
@@ -3,6 +3,8 @@ use super::service::GrpcService;
 use crate::daemon::stream::{StreamEvent, StreamFilter};
 use proto::process_manager_server::ProcessManager as ProcessManagerService;
 use proto::*;
+use std::collections::HashSet;
+use std::path::Path;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
 
@@ -18,6 +20,69 @@ fn clamp_grep_context(value: u32) -> usize {
     (value as usize).min(MAX_GREP_CONTEXT)
 }
 
+fn resolve_log_sources(
+    project: &str,
+    registry_matches: Vec<crate::common::process_key::ProcessKey>,
+    requested_names: &[String],
+    discovered_log_names: &[String],
+) -> Result<Vec<crate::common::process_key::ProcessKey>, Status> {
+    use crate::common::process_key::ProcessKey;
+    use crate::common::validation::{validate_process_name, validate_project_name};
+
+    validate_project_name(project)
+        .map_err(|e| Status::invalid_argument(format!("Invalid project name: {e}")))?;
+    for name in requested_names {
+        validate_process_name(name)
+            .map_err(|e| Status::invalid_argument(format!("Invalid process name: {e}")))?;
+    }
+
+    let mut sources = registry_matches;
+    let mut seen: HashSet<String> = sources.iter().map(|key| key.name.clone()).collect();
+    let discovered: HashSet<&str> = discovered_log_names.iter().map(String::as_str).collect();
+
+    let additional_names: Box<dyn Iterator<Item = &str> + '_> = if requested_names.is_empty() {
+        Box::new(discovered_log_names.iter().map(String::as_str))
+    } else {
+        Box::new(
+            requested_names
+                .iter()
+                .map(String::as_str)
+                .filter(|name| discovered.contains(name)),
+        )
+    };
+
+    for name in additional_names {
+        if validate_process_name(name).is_ok() && seen.insert(name.to_string()) {
+            sources.push(ProcessKey::new(project, name));
+        }
+    }
+
+    Ok(sources)
+}
+
+async fn discover_log_names(project_log_dir: &Path) -> Result<Vec<String>, std::io::Error> {
+    let mut entries = match tokio::fs::read_dir(project_log_dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    let mut names = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("log") {
+            continue;
+        }
+        if !entry.file_type().await?.is_file() {
+            continue;
+        }
+        if let Some(name) = path.file_stem().and_then(|stem| stem.to_str()) {
+            names.push(name.to_string());
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
 impl GrpcService {
     pub(super) async fn get_logs_impl(
         &self,
@@ -30,6 +95,32 @@ impl GrpcService {
         let tail = clamp_tail(req.tail.unwrap_or(100));
         let follow = req.follow.unwrap_or(false);
         let include_events = req.include_events.unwrap_or(false);
+
+        let processes = self.process_manager.list_processes().await;
+        let registry_matches: Vec<_> = processes
+            .into_iter()
+            .filter(|process| {
+                process.project == project
+                    && (process_names.is_empty() || process_names.contains(&process.name))
+            })
+            .map(|process| {
+                crate::common::process_key::ProcessKey::new(
+                    process.project.clone(),
+                    process.name.clone(),
+                )
+            })
+            .collect();
+        crate::common::validation::validate_project_name(&project)
+            .map_err(|e| Status::invalid_argument(format!("Invalid project name: {e}")))?;
+        let discovered_log_names = discover_log_names(&self.config.paths.log_dir.join(&project))
+            .await
+            .map_err(|e| Status::internal(format!("Failed to list log files: {e}")))?;
+        let log_sources = resolve_log_sources(
+            &project,
+            registry_matches,
+            &process_names,
+            &discovered_log_names,
+        )?;
 
         // Log the request details for debugging
         info!(
@@ -49,30 +140,16 @@ impl GrpcService {
 
         // For tail functionality, read existing logs from files first
         let log_hub = self.log_hub.clone();
-        let process_manager = self.process_manager.clone();
 
         // Create stream
         let stream = async_stream::try_stream! {
-            use crate::common::process_key::ProcessKey;
-
             // First, send existing logs if tail is requested
             if tail > 0 {
                 info!("Reading tail logs (tail={})", tail);
-                // Get list of processes matching the filter
-                let processes = process_manager.list_processes();
-                info!("Found {} total processes", processes.len());
-                let matching_processes: Vec<_> = processes
-                    .into_iter()
-                    .filter(|p| filter.matches_process(&p.project, &p.name))
-                    .collect();
-                info!("Found {} matching processes", matching_processes.len());
+                info!("Found {} matching log sources", log_sources.len());
 
                 // Read tail lines from each matching process's log file
-                for process_info in matching_processes {
-                    let key = ProcessKey {
-                        name: process_info.name.clone(),
-                        project: process_info.project.clone(),
-                    };
+                for key in log_sources {
                     let log_file = log_hub.get_log_file_path_for_key(&key);
 
                     if log_file.exists() {
@@ -86,7 +163,7 @@ impl GrpcService {
                                         content,
                                         timestamp,
                                         level: level as i32,
-                                        process_name: Some(process_info.name.clone()),
+                                        process_name: Some(key.name.clone()),
                                     };
 
                                     yield GetLogsResponse {
@@ -96,7 +173,7 @@ impl GrpcService {
                             }
                             Err(e) => {
                                 error!("Failed to read log file for {}/{}: {}",
-                                    process_info.project, process_info.name, e);
+                                    key.project, key.name, e);
                             }
                         }
                     }
@@ -629,9 +706,10 @@ async fn grep_log_file(
 mod tests {
     use super::{
         clamp_grep_context, clamp_tail, grep_log_file, grep_log_path, parse_time_string,
-        tail_log_lines, MAX_GREP_CONTEXT, MAX_LOG_LINES,
+        resolve_log_sources, tail_log_lines, MAX_GREP_CONTEXT, MAX_LOG_LINES,
     };
     use crate::common::config::Config;
+    use crate::common::process_key::ProcessKey;
     use crate::daemon::log::LogHub;
     use crate::daemon::stream::StreamEventHub;
     use chrono::{Local, TimeZone};
@@ -658,6 +736,51 @@ mod tests {
         assert_eq!(clamp_tail(u32::MAX), MAX_LOG_LINES);
         assert_eq!(clamp_grep_context(u32::MAX), MAX_GREP_CONTEXT);
         assert_eq!(clamp_grep_context(999), 999);
+    }
+
+    #[test]
+    fn explicit_unregistered_process_with_existing_log_is_included() {
+        let sources = resolve_log_sources(
+            "project",
+            vec![],
+            &["stopped".to_string()],
+            &["stopped".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(sources, vec![ProcessKey::new("project", "stopped")]);
+    }
+
+    #[test]
+    fn unspecified_processes_merge_discovered_logs_with_registry() {
+        let sources = resolve_log_sources(
+            "project",
+            vec![ProcessKey::new("project", "running")],
+            &[],
+            &["running".to_string(), "stopped".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            sources,
+            vec![
+                ProcessKey::new("project", "running"),
+                ProcessKey::new("project", "stopped"),
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_explicit_process_name_is_rejected() {
+        let error = resolve_log_sources(
+            "project",
+            vec![],
+            &["../escape".to_string()],
+            &["escape".to_string()],
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code(), tonic::Code::InvalidArgument);
     }
 
     #[tokio::test]

--- a/mcproc/src/daemon/api/grpc/process_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/process_handlers.rs
@@ -89,6 +89,7 @@ impl GrpcService {
         if force_restart {
             if let Some(existing) = process_manager
                 .get_process_by_name_or_id_with_project(&name, Some(project.as_str()))
+                .await
             {
                 // Stop existing process
                 force_restart_stop_result(
@@ -184,6 +185,7 @@ impl GrpcService {
         // Check if process exists
         if process_manager
             .get_process_by_name_or_id_with_project(&name, Some(&project))
+            .await
             .is_none()
         {
             return Ok(Response::new(StopProcessResponse {
@@ -307,6 +309,7 @@ impl GrpcService {
         match self
             .process_manager
             .get_process_by_name_or_id_with_project(&req.name, Some(req.project.as_str()))
+            .await
         {
             Some(process) => {
                 // Create ProcessInfo using helper
@@ -331,7 +334,7 @@ impl GrpcService {
         request: Request<ListProcessesRequest>,
     ) -> Result<Response<ListProcessesResponse>, Status> {
         let req = request.into_inner();
-        let mut processes = self.process_manager.list_processes();
+        let mut processes = self.process_manager.list_processes().await;
 
         // Filter by project if specified
         if let Some(project_filter) = req.project_filter {

--- a/mcproc/src/daemon/log/batch_writer.rs
+++ b/mcproc/src/daemon/log/batch_writer.rs
@@ -21,9 +21,8 @@ pub struct LogEntry {
 
 /// Batch writer for efficient file logging
 pub struct BatchLogWriter {
-    process_key: ProcessKey,
     tx: mpsc::Sender<LogEntry>,
-    _handle: tokio::task::JoinHandle<()>,
+    handle: tokio::task::JoinHandle<()>,
 }
 
 impl BatchLogWriter {
@@ -48,11 +47,7 @@ impl BatchLogWriter {
             }
         });
 
-        Ok(Self {
-            process_key,
-            tx,
-            _handle: handle,
-        })
+        Ok(Self { tx, handle })
     }
 
     /// Write a log entry (non-blocking)
@@ -61,6 +56,13 @@ impl BatchLogWriter {
             .send(entry)
             .await
             .map_err(|_| std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Log writer closed"))
+    }
+
+    pub async fn shutdown(self) {
+        drop(self.tx);
+        if let Err(error) = self.handle.await {
+            error!("Batch writer task failed to join: {error}");
+        }
     }
 
     /// Background task that batches and writes logs
@@ -170,15 +172,6 @@ impl BatchLogWriter {
     }
 }
 
-impl Drop for BatchLogWriter {
-    fn drop(&mut self) {
-        debug!(
-            "Dropping BatchLogWriter for {}/{}",
-            self.process_key.project, self.process_key.name
-        );
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -208,6 +201,21 @@ mod tests {
         })
         .await
         .expect("log contents were not flushed before timeout")
+    }
+
+    #[tokio::test]
+    async fn shutdown_flushes_pending_entries() {
+        let path = temp_log_path("shutdown-flush");
+        let writer = BatchLogWriter::new(ProcessKey::new("p", "n"), path.clone())
+            .await
+            .unwrap();
+        writer.write(entry(b"pending-entry")).await.unwrap();
+
+        writer.shutdown().await;
+
+        let contents = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(contents.contains("pending-entry"), "contents: {contents:?}");
+        tokio::fs::remove_file(path).await.unwrap();
     }
 
     #[tokio::test]

--- a/mcproc/src/daemon/mod.rs
+++ b/mcproc/src/daemon/mod.rs
@@ -9,7 +9,7 @@ use crate::common::config::Config;
 use fs2::FileExt;
 use std::fs::File;
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
@@ -134,7 +134,8 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
     // Stop all managed processes
     info!("Stopping all managed processes...");
-    let processes = process_manager.list_processes();
+    let processes = process_manager.list_processes().await;
+    let log_pipeline_processes = processes.clone();
     let running_processes: Vec<_> = processes
         .into_iter()
         .filter(|p| {
@@ -185,6 +186,41 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
         if failed_count > 0 {
             error!("{} process(es) failed to stop", failed_count);
+        }
+    }
+
+    let mut hyperlog_handles = Vec::new();
+    for process in log_pipeline_processes {
+        match process.hyperlog_handles.lock() {
+            Ok(mut handles) => hyperlog_handles.extend(handles.drain(..)),
+            Err(error) => warn!(
+                "Failed to collect log pipeline handles for {}/{}: {}",
+                process.project, process.name, error
+            ),
+        }
+    }
+
+    if !hyperlog_handles.is_empty() {
+        let handle_count = hyperlog_handles.len();
+        info!("Waiting for {handle_count} log pipeline task(s) to finish");
+        let mut tasks = tokio::task::JoinSet::new();
+        for handle in hyperlog_handles {
+            tasks.spawn(async move {
+                if let Err(error) = handle.await {
+                    warn!("Log pipeline task failed to join: {error}");
+                }
+            });
+        }
+
+        let wait_for_pipelines = async { while tasks.join_next().await.is_some() {} };
+        if tokio::time::timeout(tokio::time::Duration::from_secs(5), wait_for_pipelines)
+            .await
+            .is_err()
+        {
+            warn!(
+                "Timed out waiting for log pipelines; {} task(s) remain",
+                tasks.len()
+            );
         }
     }
 

--- a/mcproc/src/daemon/process/hyperlog.rs
+++ b/mcproc/src/daemon/process/hyperlog.rs
@@ -258,6 +258,10 @@ impl HyperLogStreamer {
                     tx_guard.take();
                 }
             }
+
+            if let Some(writer) = batch_writer {
+                writer.shutdown().await;
+            }
         });
 
         // Return a handle that waits for both tasks
@@ -472,17 +476,7 @@ mod tests {
             .expect("hyperlog tasks did not finish")
             .unwrap();
 
-        let contents = tokio::time::timeout(tokio::time::Duration::from_secs(2), async {
-            loop {
-                let contents = tokio::fs::read_to_string(&path).await.unwrap_or_default();
-                if contents.contains("partial") {
-                    break contents;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("partial line was not flushed");
+        let contents = tokio::fs::read_to_string(&path).await.unwrap();
         assert!(contents.contains("line1"));
         assert!(contents.contains("partial"));
         tokio::fs::remove_dir_all(root).await.unwrap();

--- a/mcproc/src/daemon/process/manager.rs
+++ b/mcproc/src/daemon/process/manager.rs
@@ -414,7 +414,7 @@ impl ProcessManager {
 
         // Detect ports before returning process info
         if matches!(proxy_arc.get_status(), ProcessStatus::Running) {
-            let ports = port_detector::detect_ports(proxy_arc.pid);
+            let ports = port_detector::detect_ports(proxy_arc.pid).await;
             if !ports.is_empty() {
                 debug!("Detected ports for process {}: {:?}", name, ports);
                 if let Some(first_port) = ports.first() {
@@ -582,7 +582,7 @@ impl ProcessManager {
         }
     }
 
-    pub fn get_process_by_name_or_id_with_project(
+    pub async fn get_process_by_name_or_id_with_project(
         &self,
         name_or_id: &str,
         project: Option<&str>,
@@ -593,7 +593,7 @@ impl ProcessManager {
 
         // Detect ports for running process
         if matches!(process.get_status(), ProcessStatus::Running) {
-            let ports = port_detector::detect_ports(process.pid);
+            let ports = port_detector::detect_ports(process.pid).await;
             if !ports.is_empty() {
                 debug!("Detected ports for process {}: {:?}", process.name, ports);
                 if let Some(first_port) = ports.first() {
@@ -609,7 +609,7 @@ impl ProcessManager {
         self.registry.get_all_processes()
     }
 
-    pub fn list_processes(&self) -> Vec<Arc<ProxyInfo>> {
+    pub async fn list_processes(&self) -> Vec<Arc<ProxyInfo>> {
         let processes = self.registry.list_processes();
 
         // Detect ports for all running processes in parallel
@@ -625,26 +625,23 @@ impl ProcessManager {
                 running_processes.len()
             );
 
-            // Create a thread pool for parallel port detection
-            use std::thread;
-            let handles: Vec<_> = running_processes
-                .into_iter()
-                .map(|process| {
-                    thread::spawn(move || {
-                        let ports = port_detector::detect_ports(process.pid);
-                        if !ports.is_empty() {
-                            debug!("Detected ports for process {}: {:?}", process.name, ports);
-                            if let Some(first_port) = ports.first() {
-                                process.set_detected_port(*first_port as u16);
-                            }
+            let mut tasks = tokio::task::JoinSet::new();
+            for process in running_processes {
+                tasks.spawn(async move {
+                    let ports = port_detector::detect_ports(process.pid).await;
+                    if !ports.is_empty() {
+                        debug!("Detected ports for process {}: {:?}", process.name, ports);
+                        if let Some(first_port) = ports.first() {
+                            process.set_detected_port(*first_port as u16);
                         }
-                    })
-                })
-                .collect();
+                    }
+                });
+            }
 
-            // Wait for all threads to complete
-            for handle in handles {
-                let _ = handle.join();
+            while let Some(result) = tasks.join_next().await {
+                if let Err(error) = result {
+                    warn!("Port detection task failed: {error}");
+                }
             }
         }
 

--- a/mcproc/src/daemon/process/port_detector.rs
+++ b/mcproc/src/daemon/process/port_detector.rs
@@ -1,10 +1,10 @@
-use std::process::Command;
+use tokio::process::Command;
 use tracing::{debug, warn};
 
 /// Detect listening ports for a given PID using lsof
-pub fn detect_ports(pid: u32) -> Vec<u32> {
+pub async fn detect_ports(pid: u32) -> Vec<u32> {
     // First, get all child PIDs
-    let all_pids = get_process_tree(pid);
+    let all_pids = get_process_tree(pid).await;
     debug!("Process tree for PID {}: {:?}", pid, all_pids);
 
     let mut all_ports = Vec::new();
@@ -21,6 +21,7 @@ pub fn detect_ports(pid: u32) -> Vec<u32> {
                 "-sTCP:LISTEN",         // Only listening state
             ])
             .output()
+            .await
         {
             Ok(output) => output,
             Err(e) => {
@@ -65,23 +66,26 @@ pub fn detect_ports(pid: u32) -> Vec<u32> {
 }
 
 /// Get process tree - parent PID and all its children
-fn get_process_tree(pid: u32) -> Vec<u32> {
+async fn get_process_tree(pid: u32) -> Vec<u32> {
     let mut pids = vec![pid];
+    let mut next_index = 0;
 
-    // Use pgrep to find child processes
-    if let Ok(output) = Command::new("pgrep")
-        .args(["-P", &pid.to_string()])
-        .output()
-    {
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            for line in stdout.lines() {
-                if let Ok(child_pid) = line.trim().parse::<u32>() {
-                    // Recursively get children of children
-                    let child_tree = get_process_tree(child_pid);
-                    for cpid in child_tree {
-                        if !pids.contains(&cpid) {
-                            pids.push(cpid);
+    while next_index < pids.len() {
+        let parent_pid = pids[next_index];
+        next_index += 1;
+
+        // Use pgrep to find child processes
+        if let Ok(output) = Command::new("pgrep")
+            .args(["-P", &parent_pid.to_string()])
+            .output()
+            .await
+        {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                for line in stdout.lines() {
+                    if let Ok(child_pid) = line.trim().parse::<u32>() {
+                        if !pids.contains(&child_pid) {
+                            pids.push(child_pid);
                         }
                     }
                 }
@@ -109,13 +113,16 @@ fn extract_port(name: &str) -> Option<&str> {
 
 /// Alternative implementation using netstat (for systems without lsof)
 #[allow(dead_code)]
-pub fn detect_ports_netstat(pid: u32) -> Vec<u32> {
+pub async fn detect_ports_netstat(pid: u32) -> Vec<u32> {
     // Try netstat with different options based on OS
     let output = if cfg!(target_os = "macos") {
-        Command::new("netstat").args(["-anv", "-p", "tcp"]).output()
+        Command::new("netstat")
+            .args(["-anv", "-p", "tcp"])
+            .output()
+            .await
     } else {
         // Linux
-        Command::new("netstat").args(["-tlnp"]).output()
+        Command::new("netstat").args(["-tlnp"]).output().await
     };
 
     let output = match output {
@@ -170,5 +177,10 @@ mod tests {
         assert_eq!(extract_port("[::]:3000"), Some("3000"));
         assert_eq!(extract_port("[::1]:8080"), Some("8080"));
         assert_eq!(extract_port("localhost"), None);
+    }
+
+    #[tokio::test]
+    async fn detect_ports_is_awaitable() {
+        let _ = detect_ports(u32::MAX).await;
     }
 }

--- a/mcproc/src/daemon/process/proxy.rs
+++ b/mcproc/src/daemon/process/proxy.rs
@@ -239,7 +239,14 @@ impl ProxyInfo {
 
     #[cfg(unix)]
     async fn confirm_stopped_after_force_kill(&self) -> Result<(), String> {
-        let timeout = tokio::time::Duration::from_secs(2);
+        // Generous deadline: SIGKILL cleanup (zombie transition and reaping)
+        // can stretch to seconds under CPU starvation from parallel builds/CI.
+        self.confirm_stopped_within(tokio::time::Duration::from_secs(10))
+            .await
+    }
+
+    #[cfg(unix)]
+    async fn confirm_stopped_within(&self, timeout: tokio::time::Duration) -> Result<(), String> {
         let start = tokio::time::Instant::now();
         while start.elapsed() < timeout {
             if !Self::is_process_group_alive(self.pid) {
@@ -342,7 +349,9 @@ mod tests {
         let pid = child.id().unwrap();
         let proxy = proxy_for_pid(pid);
 
-        let result = proxy.confirm_stopped_after_force_kill().await;
+        let result = proxy
+            .confirm_stopped_within(tokio::time::Duration::from_millis(300))
+            .await;
 
         assert!(
             result.is_err(),


### PR DESCRIPTION
## Summary

Resolves the four remaining follow-up issues from the source code review (PR #43): #40, #41, #46, #47.

Fixes #40
Fixes #41
Fixes #46
Fixes #47

## Changes

### #40 — `get_logs` can now read logs of stopped processes

`get_logs_impl` previously discovered log files only through registry entries, so logs of processes that had stopped (and been removed) or that predate a daemon restart were unreachable even though the files exist on disk.

- Explicitly requested process names fall back to the on-disk log file when there is no registry match.
- Requests without names merge `*.log` files discovered in the project log directory with the registry matches.
- Project and process names are validated before the stream is built (`InvalidArgument` on bad input); discovered file stems that fail validation are skipped.

### #41 — Port detection no longer blocks the async runtime

`detect_ports` / `get_process_tree` shelled out to `lsof`/`pgrep` with blocking `std::process::Command` from async contexts. They now use `tokio::process::Command`, the recursive tree walk is converted to an iterative loop, and the per-process OS-thread workaround in `list_processes` is replaced with a `JoinSet`. Callers (`manager`, gRPC handlers, shutdown path) are async-adjusted.

### #46 — MCP notifications are drained while tool calls execute

The mcp-rs server loop awaited each request inline, so notifications from a running tool (e.g. log streaming during `start_process`) buffered without bound in the unbounded channel and arrived only after the response.

- Requests are handled in spawned tasks tracked by a `JoinSet`.
- Responses and notifications flow through a single bounded `mpsc::channel(1024)` drained continuously by the main loop — backpressure is restored and ordering (notifications before their response) is guaranteed.
- On transport close the loop drains until all handlers finish and the queue is empty before closing.
- New tests: notification-before-response ordering (Red on the old implementation), and a tool emitting 1500 notifications (over channel capacity) without deadlock.

### #47 — Daemon shutdown drains the log pipeline

Shutdown previously exited the runtime without waiting for buffered logs.

- `BatchLogWriter::shutdown()` closes the channel and joins the writer task; the hyperlog processor awaits it before exiting, so a hyperlog `JoinHandle` completing now means the file is fully flushed.
- `run_daemon` collects all hyperlog handles after stopping processes and joins them with a 5-second deadline before removing the PID file.

### Flaky-test hardening (found while validating)

`test_stop_kills_orphaned_grandchild` failed under parallel-build CPU starvation: zombie transition and reaping after SIGKILL can stretch to seconds, exceeding the 2s post-SIGKILL confirmation window. The window is widened to 10s (normal path exits on the first poll); unit tests inject a short deadline via `confirm_stopped_within`. Verified with 20 repetitions of the integration test plus 3 full-suite runs, all under 8-way CPU load — 0 failures.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — mcp-rs: 6 passed / mcproc lib: 60 passed / mcproc bin: 61 passed / process_group_test: 2 passed (integration: 4 ignored, require installed binary)
- [x] Flaky check: 20× `test_stop_kills_orphaned_grandchild` + 3× full suite under 8-way CPU load — 0 failures
