### PR TITLE
refactor: move port detection ownership to the periodic sync task

### DIFF
--- a/mcproc/src/common/config/mod.rs
+++ b/mcproc/src/common/config/mod.rs
@@ -69,8 +69,6 @@ pub struct ProcessConfig {
     pub startup: ProcessStartupConfig,
     /// Restart configuration
     pub restart: ProcessRestartConfig,
-    /// Port detection configuration
-    pub port_detection: PortDetectionConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,16 +87,6 @@ pub struct ProcessRestartConfig {
     pub delay_ms: u64,
     /// Timeout for graceful shutdown of a single process (milliseconds)
     pub process_stop_timeout_ms: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PortDetectionConfig {
-    /// Initial delay before starting port detection (seconds)
-    pub initial_delay_secs: u64,
-    /// Interval between port detection attempts (seconds)
-    pub interval_secs: u64,
-    /// Maximum number of port detection attempts
-    pub max_attempts: u32,
 }
 
 impl Default for Config {
@@ -135,11 +123,6 @@ impl Default for Config {
                     max_attempts: 3,
                     delay_ms: 1000,
                     process_stop_timeout_ms: 30000, // 30 seconds per process
-                },
-                port_detection: PortDetectionConfig {
-                    initial_delay_secs: 3,
-                    interval_secs: 3,
-                    max_attempts: 30,
                 },
             },
             logging: LoggingConfig {

--- a/mcproc/src/daemon/api/grpc/log_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/log_handlers.rs
@@ -96,7 +96,7 @@ impl GrpcService {
         let follow = req.follow.unwrap_or(false);
         let include_events = req.include_events.unwrap_or(false);
 
-        let processes = self.process_manager.list_processes().await;
+        let processes = self.process_manager.get_all_processes();
         let registry_matches: Vec<_> = processes
             .into_iter()
             .filter(|process| {

--- a/mcproc/src/daemon/api/grpc/process_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/process_handlers.rs
@@ -89,7 +89,6 @@ impl GrpcService {
         if force_restart {
             if let Some(existing) = process_manager
                 .get_process_by_name_or_id_with_project(&name, Some(project.as_str()))
-                .await
             {
                 // Stop existing process
                 force_restart_stop_result(
@@ -185,7 +184,6 @@ impl GrpcService {
         // Check if process exists
         if process_manager
             .get_process_by_name_or_id_with_project(&name, Some(&project))
-            .await
             .is_none()
         {
             return Ok(Response::new(StopProcessResponse {
@@ -309,7 +307,6 @@ impl GrpcService {
         match self
             .process_manager
             .get_process_by_name_or_id_with_project(&req.name, Some(req.project.as_str()))
-            .await
         {
             Some(process) => {
                 // Create ProcessInfo using helper
@@ -334,7 +331,7 @@ impl GrpcService {
         request: Request<ListProcessesRequest>,
     ) -> Result<Response<ListProcessesResponse>, Status> {
         let req = request.into_inner();
-        let mut processes = self.process_manager.list_processes().await;
+        let mut processes = self.process_manager.get_all_processes();
 
         // Filter by project if specified
         if let Some(project_filter) = req.project_filter {

--- a/mcproc/src/daemon/mod.rs
+++ b/mcproc/src/daemon/mod.rs
@@ -134,7 +134,7 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
     // Stop all managed processes
     info!("Stopping all managed processes...");
-    let processes = process_manager.list_processes().await;
+    let processes = process_manager.get_all_processes();
     let log_pipeline_processes = processes.clone();
     let running_processes: Vec<_> = processes
         .into_iter()

--- a/mcproc/src/daemon/process/manager.rs
+++ b/mcproc/src/daemon/process/manager.rs
@@ -417,10 +417,8 @@ impl ProcessManager {
             let ports = port_detector::detect_ports(proxy_arc.pid).await;
             if !ports.is_empty() {
                 debug!("Detected ports for process {}: {:?}", name, ports);
-                if let Some(first_port) = ports.first() {
-                    proxy_arc.set_detected_port(*first_port as u16);
-                }
             }
+            proxy_arc.update_detected_port(&ports);
         }
 
         Ok((
@@ -582,70 +580,17 @@ impl ProcessManager {
         }
     }
 
-    pub async fn get_process_by_name_or_id_with_project(
+    pub fn get_process_by_name_or_id_with_project(
         &self,
         name_or_id: &str,
         project: Option<&str>,
     ) -> Option<Arc<ProxyInfo>> {
-        let process = self
-            .registry
-            .get_process_by_name_or_id_with_project(name_or_id, project)?;
-
-        // Detect ports for running process
-        if matches!(process.get_status(), ProcessStatus::Running) {
-            let ports = port_detector::detect_ports(process.pid).await;
-            if !ports.is_empty() {
-                debug!("Detected ports for process {}: {:?}", process.name, ports);
-                if let Some(first_port) = ports.first() {
-                    process.set_detected_port(*first_port as u16);
-                }
-            }
-        }
-
-        Some(process)
+        self.registry
+            .get_process_by_name_or_id_with_project(name_or_id, project)
     }
 
     pub fn get_all_processes(&self) -> Vec<Arc<ProxyInfo>> {
         self.registry.get_all_processes()
-    }
-
-    pub async fn list_processes(&self) -> Vec<Arc<ProxyInfo>> {
-        let processes = self.registry.list_processes();
-
-        // Detect ports for all running processes in parallel
-        let running_processes: Vec<_> = processes
-            .iter()
-            .filter(|p| matches!(p.get_status(), ProcessStatus::Running))
-            .cloned()
-            .collect();
-
-        if !running_processes.is_empty() {
-            debug!(
-                "Detecting ports for {} running processes",
-                running_processes.len()
-            );
-
-            let mut tasks = tokio::task::JoinSet::new();
-            for process in running_processes {
-                tasks.spawn(async move {
-                    let ports = port_detector::detect_ports(process.pid).await;
-                    if !ports.is_empty() {
-                        debug!("Detected ports for process {}: {:?}", process.name, ports);
-                        if let Some(first_port) = ports.first() {
-                            process.set_detected_port(*first_port as u16);
-                        }
-                    }
-                });
-            }
-
-            while let Some(result) = tasks.join_next().await {
-                if let Err(error) = result {
-                    warn!("Port detection task failed: {error}");
-                }
-            }
-        }
-
-        processes
     }
 
     pub async fn clean_project(
@@ -803,15 +748,16 @@ impl ProcessManager {
                 interval.tick().await;
 
                 // Get all processes that should be checked
-                let processes = registry.list_processes();
+                let processes = registry.get_all_processes();
                 let active_processes: Vec<_> = processes
-                    .into_iter()
+                    .iter()
                     .filter(|p| {
                         matches!(
                             p.get_status(),
                             ProcessStatus::Running | ProcessStatus::Starting
                         )
                     })
+                    .cloned()
                     .collect();
 
                 if !active_processes.is_empty() {
@@ -825,10 +771,36 @@ impl ProcessManager {
                         Self::sync_process_status_static(&process).await;
                     }
                 }
+
+                Self::refresh_detected_ports(&processes).await;
             }
         });
 
         info!("Started periodic process state synchronization (interval: 10s)");
+    }
+
+    async fn refresh_detected_ports(processes: &[Arc<ProxyInfo>]) {
+        let mut tasks = tokio::task::JoinSet::new();
+
+        for process in processes
+            .iter()
+            .filter(|process| matches!(process.get_status(), ProcessStatus::Running))
+            .cloned()
+        {
+            tasks.spawn(async move {
+                let ports = port_detector::detect_ports(process.pid).await;
+                if !ports.is_empty() {
+                    debug!("Detected ports for process {}: {:?}", process.name, ports);
+                }
+                process.update_detected_port(&ports);
+            });
+        }
+
+        while let Some(result) = tasks.join_next().await {
+            if let Err(error) = result {
+                warn!("Port detection task failed: {error}");
+            }
+        }
     }
 
     /// Static version of sync_process_status for use in background tasks

--- a/mcproc/src/daemon/process/proxy.rs
+++ b/mcproc/src/daemon/process/proxy.rs
@@ -287,9 +287,9 @@ impl ProxyInfo {
         })
     }
 
-    pub fn set_detected_port(&self, port: u16) {
+    pub fn update_detected_port(&self, ports: &[u32]) {
         if let Ok(mut detected) = self.detected_port.lock() {
-            *detected = Some(port);
+            *detected = ports.first().map(|port| *port as u16);
         }
     }
 
@@ -337,6 +337,17 @@ mod tests {
             toolchain: None,
             pid,
         })
+    }
+
+    #[test]
+    fn update_detected_port_sets_first_port_and_clears_empty_result() {
+        let proxy = proxy_for_pid(1234);
+
+        proxy.update_detected_port(&[8080, 8081]);
+        assert_eq!(*proxy.detected_port.lock().unwrap(), Some(8080));
+
+        proxy.update_detected_port(&[]);
+        assert_eq!(*proxy.detected_port.lock().unwrap(), None);
     }
 
     #[tokio::test]

--- a/mcproc/src/daemon/process/registry.rs
+++ b/mcproc/src/daemon/process/registry.rs
@@ -112,11 +112,6 @@ impl ProcessRegistry {
             .collect()
     }
 
-    /// List processes (same as get_all_processes for compatibility)
-    pub fn list_processes(&self) -> Vec<Arc<ProxyInfo>> {
-        self.get_all_processes()
-    }
-
     /// Get processes by project
     pub fn get_processes_by_project(&self, project: &str) -> Vec<Arc<ProxyInfo>> {
         self.processes


### PR DESCRIPTION
## Summary

Fixes #48 (follow-up to #41).

Port detection was still triggered ad-hoc from read paths (`list_processes`, `get_process_by_name_or_id_with_project`), so a polling client spawned `lsof`/`pgrep` subprocesses on every status/list call.

## Changes

- **Periodic sync owns detection**: the existing 10s sync loop now refreshes `detected_port` for all running processes concurrently (`refresh_detected_ports`, JoinSet), and **clears it when a process stops listening** — `update_detected_port(&[u32])` stores the first port or `None`, replacing `set_detected_port(u16)` which had no clear path.
- **Read paths are pure cache reads**: the side-effecting async `list_processes` is removed in favor of the pure `get_all_processes()`, and `get_process_by_name_or_id_with_project` is back to a sync registry lookup. This also resolves the confusing `get_all_processes` / `list_processes` API pair (the registry's duplicate alias is removed too).
- **Startup detection kept**: the one-shot detection right after process startup remains, so the start response still reports ports immediately when available.
- **Dead config removed**: `PortDetectionConfig` was defined and constructed but never read. serde ignores the unknown table, so existing `config.toml` files keep working.

Trade-off: ports shown by `ps`/status can now be up to 10s stale, in exchange for zero subprocess spawns on read paths (as proposed in #48).

Not addressed (noted as residual in #48): the minor PID-reuse TOCTOU inside `detect_ports` itself.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — mcp-rs: 6 passed / mcproc lib: 61 passed / mcproc bin: 62 passed / process_group_test: 2 passed (integration: 4 ignored, require installed binary)
- [x] New test: `update_detected_port_sets_first_port_and_clears_empty_result` (test-first, Red confirmed)