### PR TITLE
test: raise line coverage from 41% to 69% and enforce integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,48 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+  integration-tests:
+    name: Integration tests (installed binary)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protobuf compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release -p mcproc
+
+      - name: Add release binary to PATH
+        run: echo "$GITHUB_WORKSPACE/target/release" >> "$GITHUB_PATH"
+
+      - name: Run ignored integration tests
+        run: cargo test --test process_stop_test --test daemon_shutdown_test -- --ignored --test-threads=1
+
+      - name: Stop daemon
+        if: always()
+        run: mcproc daemon stop || true
+
+      - name: Show daemon log on failure
+        if: failure()
+        run: |
+          state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
+          log_file="$state_home/mcproc/log/mcprocd.log"
+          if [[ -f "$log_file" ]]; then
+            cat "$log_file"
+          else
+            echo "Daemon log not found at $log_file; skipping."
+          fi
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,29 +60,14 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Build release binary
-        run: cargo build --release -p mcproc
+      - name: Build debug binary
+        run: cargo build -p mcproc
 
-      - name: Add release binary to PATH
-        run: echo "$GITHUB_WORKSPACE/target/release" >> "$GITHUB_PATH"
+      - name: Add debug binary to PATH
+        run: echo "$GITHUB_WORKSPACE/target/debug" >> "$GITHUB_PATH"
 
       - name: Run ignored integration tests
         run: cargo test --test process_stop_test --test daemon_shutdown_test -- --ignored --test-threads=1
-
-      - name: Stop daemon
-        if: always()
-        run: mcproc daemon stop || true
-
-      - name: Show daemon log on failure
-        if: failure()
-        run: |
-          state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
-          log_file="$state_home/mcproc/log/mcprocd.log"
-          if [[ -f "$log_file" ]]; then
-            cat "$log_file"
-          else
-            echo "Daemon log not found at $log_file; skipping."
-          fi
 
   lint:
     name: Lint

--- a/mcp-rs/src/error.rs
+++ b/mcp-rs/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error("Invalid params: {0}")]
     InvalidParams(String),
 
+    #[error("Tool not found: {0}")]
+    ToolNotFound(String),
+
     #[error("Internal error: {0}")]
     Internal(String),
 

--- a/mcp-rs/src/notification.rs
+++ b/mcp-rs/src/notification.rs
@@ -138,3 +138,66 @@ impl NotificationSender for QueuedNotificationSender {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{JsonRpcId, MessageLevel};
+
+    #[tokio::test]
+    async fn tool_context_send_log_queues_message_notification() {
+        let sender = Arc::new(QueuedNotificationSender::new());
+        let context = ToolContext::new(
+            sender.clone(),
+            None,
+            Some(JsonRpcId::String("request-1".to_string())),
+        );
+
+        context
+            .send_log(MessageLevel::Info, "tool started".to_string())
+            .await
+            .unwrap();
+
+        let notifications = sender.take_all().await;
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0].jsonrpc, "2.0");
+        assert_eq!(notifications[0].method, "notifications/message");
+        assert_eq!(
+            notifications[0].params,
+            Some(json!({
+                "level": "info",
+                "logger": "mcproc",
+                "data": { "message": "tool started" }
+            }))
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_context_send_progress_queues_progress_notification() {
+        let sender = Arc::new(QueuedNotificationSender::new());
+        let context = ToolContext::new(
+            sender.clone(),
+            Some("progress-1".to_string()),
+            Some(JsonRpcId::Number(7)),
+        );
+
+        context
+            .send_progress(2, 5, Some("working".to_string()))
+            .await
+            .unwrap();
+
+        let notifications = sender.take_all().await;
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0].jsonrpc, "2.0");
+        assert_eq!(notifications[0].method, "notifications/progress");
+        assert_eq!(
+            notifications[0].params,
+            Some(json!({
+                "progressToken": "progress-1",
+                "progress": 2,
+                "total": 5,
+                "message": "working"
+            }))
+        );
+    }
+}

--- a/mcp-rs/src/protocol.rs
+++ b/mcp-rs/src/protocol.rs
@@ -313,10 +313,8 @@ impl Protocol {
                 }
             }
         } else {
-            Err(Error::MethodNotFound(format!(
-                "Tool not found: {}",
-                tool_name
-            )))
+            // MCP spec: unknown tool is an Invalid params error, not Method not found
+            Err(Error::InvalidParams(format!("Unknown tool: {}", tool_name)))
         }
     }
 
@@ -389,6 +387,79 @@ impl Protocol {
 mod tests {
     use super::*;
 
+    struct FixedTool;
+
+    #[async_trait]
+    impl ToolHandler for FixedTool {
+        fn tool_info(&self) -> ToolInfo {
+            ToolInfo {
+                name: "fixed".to_string(),
+                description: "Returns a fixed value".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "ignored": { "type": "string" }
+                    }
+                }),
+            }
+        }
+
+        async fn handle(
+            &self,
+            _params: Option<Value>,
+            _context: crate::notification::ToolContext,
+        ) -> Result<Value> {
+            Ok(json!({ "answer": 42 }))
+        }
+    }
+
+    fn request(method: &str, params: Option<Value>, id: JsonRpcId) -> JsonRpcMessage {
+        JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params,
+            id,
+        })
+    }
+
+    fn notification(method: &str, params: Option<Value>) -> JsonRpcMessage {
+        JsonRpcMessage::Notification(JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: method.to_string(),
+            params,
+        })
+    }
+
+    fn response(message: Option<JsonRpcMessage>) -> JsonRpcResponse {
+        match message {
+            Some(JsonRpcMessage::Response(response)) => response,
+            other => panic!("expected response, got {other:?}"),
+        }
+    }
+
+    fn batch(message: Option<JsonRpcMessage>) -> Vec<JsonRpcMessage> {
+        match message {
+            Some(JsonRpcMessage::Batch(batch)) => batch,
+            other => panic!("expected batch response, got {other:?}"),
+        }
+    }
+
+    fn result(response: &JsonRpcResponse) -> &Value {
+        assert!(response.error.is_none());
+        match response.result.as_ref() {
+            Some(result) => result,
+            None => panic!("expected successful result, got {response:?}"),
+        }
+    }
+
+    fn error(response: &JsonRpcResponse) -> &JsonRpcError {
+        assert!(response.result.is_none());
+        match response.error.as_ref() {
+            Some(error) => error,
+            None => panic!("expected error, got {response:?}"),
+        }
+    }
+
     fn assert_invalid_request(message: Option<JsonRpcMessage>) {
         match message {
             Some(JsonRpcMessage::Response(response)) => {
@@ -433,5 +504,243 @@ mod tests {
             }
             other => panic!("expected invalid-request response, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_server_metadata_and_capabilities() {
+        let protocol = Protocol::new("test-server".to_string(), "1.2.3".to_string());
+        let response = response(
+            protocol
+                .handle_message_realtime(request(
+                    "initialize",
+                    Some(json!({
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test-client", "version": "1" }
+                    })),
+                    JsonRpcId::String("init-1".to_string()),
+                ))
+                .await,
+        );
+
+        assert_eq!(response.jsonrpc, "2.0");
+        assert_eq!(response.id, JsonRpcId::String("init-1".to_string()));
+        assert_eq!(result(&response)["protocolVersion"], "2025-03-26");
+        assert_eq!(result(&response)["serverInfo"]["name"], "test-server");
+        assert_eq!(result(&response)["serverInfo"]["version"], "1.2.3");
+        assert!(result(&response)["capabilities"]["tools"].is_object());
+    }
+
+    #[tokio::test]
+    async fn tools_list_returns_registered_tool_metadata() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+        protocol.register_tool(Arc::new(FixedTool)).await;
+
+        let response = response(
+            protocol
+                .handle_message_realtime(request("tools/list", None, JsonRpcId::Number(1)))
+                .await,
+        );
+        let tools = match result(&response)["tools"].as_array() {
+            Some(tools) => tools,
+            None => panic!("expected tools array"),
+        };
+
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], "fixed");
+        assert_eq!(tools[0]["description"], "Returns a fixed value");
+        assert_eq!(
+            tools[0]["inputSchema"],
+            json!({
+                "type": "object",
+                "properties": {
+                    "ignored": { "type": "string" }
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn tools_call_returns_tool_result_and_echoes_id() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+        protocol.register_tool(Arc::new(FixedTool)).await;
+
+        let response = response(
+            protocol
+                .handle_message_realtime(request(
+                    "tools/call",
+                    Some(json!({ "name": "fixed", "arguments": { "ignored": "x" } })),
+                    JsonRpcId::String("call-1".to_string()),
+                ))
+                .await,
+        );
+
+        assert_eq!(response.id, JsonRpcId::String("call-1".to_string()));
+        assert_eq!(result(&response)["isError"], false);
+        assert_eq!(result(&response)["content"][0]["type"], "text");
+        assert_eq!(
+            result(&response)["content"][0]["text"],
+            serde_json::to_string_pretty(&json!({ "answer": 42 })).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn tools_call_missing_params_or_name_returns_invalid_params() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+        let cases = [
+            (None, JsonRpcId::Number(10)),
+            (Some(json!({})), JsonRpcId::Number(11)),
+        ];
+
+        for (params, id) in cases {
+            let response = response(
+                protocol
+                    .handle_message_realtime(request("tools/call", params, id.clone()))
+                    .await,
+            );
+
+            assert_eq!(response.id, id);
+            assert_eq!(error(&response).code, error_codes::INVALID_PARAMS);
+        }
+    }
+
+    #[tokio::test]
+    async fn tools_call_unknown_tool_returns_invalid_params() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+
+        let response = response(
+            protocol
+                .handle_message_realtime(request(
+                    "tools/call",
+                    Some(json!({ "name": "no-such-tool", "arguments": {} })),
+                    JsonRpcId::Number(12),
+                ))
+                .await,
+        );
+
+        // MCP spec: unknown tool is an Invalid params error (-32602), not
+        // Method not found (https://modelcontextprotocol.io/specification/2025-03-26/server/tools)
+        assert_eq!(error(&response).code, error_codes::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn error_variants_map_to_json_rpc_error_codes() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+        let serialization_error = match serde_json::from_str::<Value>("{") {
+            Err(error) => error,
+            Ok(value) => panic!("expected malformed JSON to fail, got {value}"),
+        };
+        let cases = [
+            (
+                Error::Transport("transport".to_string()),
+                error_codes::SERVER_ERROR,
+            ),
+            (
+                Error::Protocol("protocol".to_string()),
+                error_codes::SERVER_ERROR,
+            ),
+            (
+                Error::Serialization(serialization_error),
+                error_codes::SERVER_ERROR,
+            ),
+            (
+                Error::Io(std::io::Error::other("io")),
+                error_codes::SERVER_ERROR,
+            ),
+            (
+                Error::MethodNotFound("missing".to_string()),
+                error_codes::METHOD_NOT_FOUND,
+            ),
+            (
+                Error::InvalidParams("invalid".to_string()),
+                error_codes::INVALID_PARAMS,
+            ),
+            (
+                Error::Internal("internal".to_string()),
+                error_codes::INTERNAL_ERROR,
+            ),
+            (
+                Error::NotImplemented("todo".to_string()),
+                error_codes::SERVER_ERROR,
+            ),
+        ];
+
+        for (source, expected_code) in cases {
+            let mapped = protocol.error_to_json_rpc(source);
+            assert_eq!(mapped.code, expected_code);
+            assert!(mapped.data.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_custom_method_returns_method_not_found() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+        let response = response(
+            protocol
+                .handle_message_realtime(request("unknown/custom", None, JsonRpcId::Number(20)))
+                .await,
+        );
+
+        assert_eq!(response.id, JsonRpcId::Number(20));
+        assert_eq!(error(&response).code, error_codes::METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn nonempty_batch_returns_responses_in_request_order() {
+        let protocol = Protocol::new("test-server".to_string(), "1".to_string());
+        let responses = batch(
+            protocol
+                .handle_message_realtime(JsonRpcMessage::Batch(vec![
+                    request("initialize", None, JsonRpcId::Number(31)),
+                    request("tools/list", None, JsonRpcId::Number(32)),
+                ]))
+                .await,
+        );
+
+        assert_eq!(responses.len(), 2);
+        for (message, expected_id) in responses.iter().zip([31, 32]) {
+            match message {
+                JsonRpcMessage::Response(response) => {
+                    assert_eq!(response.id, JsonRpcId::Number(expected_id));
+                    assert!(response.error.is_none());
+                }
+                other => panic!("expected response in batch, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_omits_notification_response() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+        let responses = batch(
+            protocol
+                .handle_message_realtime(JsonRpcMessage::Batch(vec![
+                    request("tools/list", None, JsonRpcId::Number(41)),
+                    notification("notifications/initialized", None),
+                ]))
+                .await,
+        );
+
+        assert_eq!(responses.len(), 1);
+        match &responses[0] {
+            JsonRpcMessage::Response(response) => {
+                assert_eq!(response.id, JsonRpcId::Number(41));
+            }
+            other => panic!("expected response in batch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn standalone_notification_produces_no_response() {
+        let protocol = Protocol::new("test".to_string(), "1".to_string());
+
+        let response = protocol
+            .handle_message_realtime(notification(
+                "notifications/initialized",
+                Some(json!({ "ready": true })),
+            ))
+            .await;
+
+        assert!(response.is_none());
     }
 }

--- a/mcp-rs/src/protocol.rs
+++ b/mcp-rs/src/protocol.rs
@@ -314,7 +314,7 @@ impl Protocol {
             }
         } else {
             // MCP spec: unknown tool is an Invalid params error, not Method not found
-            Err(Error::InvalidParams(format!("Unknown tool: {}", tool_name)))
+            Err(Error::ToolNotFound(tool_name.to_string()))
         }
     }
 
@@ -367,6 +367,11 @@ impl Protocol {
             Error::InvalidParams(msg) => JsonRpcError {
                 code: error_codes::INVALID_PARAMS,
                 message: msg,
+                data: None,
+            },
+            Error::ToolNotFound(tool_name) => JsonRpcError {
+                code: error_codes::INVALID_PARAMS,
+                message: Error::ToolNotFound(tool_name).to_string(),
                 data: None,
             },
             Error::Internal(msg) => JsonRpcError {
@@ -653,6 +658,10 @@ mod tests {
             ),
             (
                 Error::InvalidParams("invalid".to_string()),
+                error_codes::INVALID_PARAMS,
+            ),
+            (
+                Error::ToolNotFound("missing-tool".to_string()),
                 error_codes::INVALID_PARAMS,
             ),
             (

--- a/mcproc/src/cli/commands/mcp/mod.rs
+++ b/mcproc/src/cli/commands/mcp/mod.rs
@@ -2,6 +2,11 @@
 
 pub mod tools;
 
+#[cfg(test)]
+mod test_support;
+#[cfg(test)]
+mod tests;
+
 use crate::client::DaemonClient;
 use clap::{Parser, Subcommand};
 use std::sync::Arc;

--- a/mcproc/src/cli/commands/mcp/test_support.rs
+++ b/mcproc/src/cli/commands/mcp/test_support.rs
@@ -1,0 +1,135 @@
+use crate::client::DaemonClient;
+use crate::common::config::Config;
+use crate::daemon::api::grpc::service::GrpcService;
+use crate::daemon::log::LogHub;
+use crate::daemon::process::ProcessManager;
+use crate::daemon::stream::StreamEventHub;
+use hyper_util::rt::tokio::TokioIo;
+use mcp_rs::notification::QueuedNotificationSender;
+use mcp_rs::ToolContext;
+use proto::process_manager_server::ProcessManagerServer;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::{UnixListener, UnixStream};
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::transport::{Endpoint, Server, Uri};
+use tower::service_fn;
+
+pub(super) struct McpTestHarness {
+    pub client: DaemonClient,
+    process_manager: Arc<ProcessManager>,
+    root: PathBuf,
+    server_task: JoinHandle<()>,
+}
+
+impl McpTestHarness {
+    pub async fn new() -> Self {
+        let root = PathBuf::from(format!("/tmp/mcp-{}", uuid::Uuid::new_v4()));
+        let socket_path = root.join("s");
+
+        let mut config = Config::default();
+        config.paths.data_dir = root.join("data");
+        config.paths.log_dir = root.join("log");
+        config.paths.socket_path = socket_path.clone();
+        config.paths.pid_file = root.join("pid");
+        config.paths.daemon_log_file = root.join("daemon.log");
+        config.process.restart.delay_ms = 0;
+        config.process.restart.process_stop_timeout_ms = 10_000;
+        config.ensure_directories().unwrap();
+
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let config = Arc::new(config);
+        let event_hub = Arc::new(StreamEventHub::new());
+        let log_hub = Arc::new(LogHub::with_event_hub(config.clone(), event_hub.clone()));
+        let process_manager = Arc::new(ProcessManager::with_event_hub(
+            config.clone(),
+            log_hub.clone(),
+            event_hub.clone(),
+        ));
+        let service = GrpcService::new(process_manager.clone(), log_hub, config, event_hub);
+
+        let server_task = tokio::spawn(async move {
+            Server::builder()
+                .add_service(ProcessManagerServer::new(service))
+                .serve_with_incoming(UnixListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+
+        let channel = Endpoint::from_static("http://[::]:50051")
+            .connect_timeout(Duration::from_secs(2))
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let socket_path = socket_path.clone();
+                async move {
+                    let stream = UnixStream::connect(socket_path).await?;
+                    Ok::<_, std::io::Error>(TokioIo::new(stream))
+                }
+            }))
+            .await
+            .unwrap();
+
+        Self {
+            client: DaemonClient::from_channel(channel),
+            process_manager,
+            root,
+            server_task,
+        }
+    }
+
+    pub fn context() -> ToolContext {
+        ToolContext::new(Arc::new(QueuedNotificationSender::new()), None, None)
+    }
+
+    pub async fn wait_for_log(&self, path: &str, needles: &[&str]) -> String {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let contents = tokio::fs::read_to_string(path).await.unwrap_or_default();
+                if needles.iter().all(|needle| contents.contains(needle)) {
+                    return contents;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("process log was not flushed before the deadline")
+    }
+
+    pub async fn cleanup(mut self) {
+        self.stop_all().await;
+        self.server_task.abort();
+        let _ = (&mut self.server_task).await;
+        std::fs::remove_dir_all(&self.root).unwrap();
+        self.root = PathBuf::new();
+    }
+
+    async fn stop_all(&self) {
+        for process in self.process_manager.get_all_processes() {
+            let stop = self
+                .process_manager
+                .stop_process(&process.id, Some(&process.project), true);
+            tokio::time::timeout(Duration::from_secs(15), stop)
+                .await
+                .expect("managed process stop exceeded cleanup deadline")
+                .expect("managed process cleanup failed");
+        }
+    }
+}
+
+impl Drop for McpTestHarness {
+    fn drop(&mut self) {
+        self.server_task.abort();
+
+        #[cfg(unix)]
+        for process in self.process_manager.get_all_processes() {
+            unsafe {
+                libc::kill(-(process.pid as i32), libc::SIGKILL);
+            }
+        }
+
+        if !self.root.as_os_str().is_empty() {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+}

--- a/mcproc/src/cli/commands/mcp/test_support.rs
+++ b/mcproc/src/cli/commands/mcp/test_support.rs
@@ -1,14 +1,9 @@
 use crate::client::DaemonClient;
-use crate::common::config::Config;
-use crate::daemon::api::grpc::service::GrpcService;
-use crate::daemon::log::LogHub;
-use crate::daemon::process::ProcessManager;
-use crate::daemon::stream::StreamEventHub;
+use crate::test_support::ProcessTestFixture;
 use hyper_util::rt::tokio::TokioIo;
 use mcp_rs::notification::QueuedNotificationSender;
 use mcp_rs::ToolContext;
 use proto::process_manager_server::ProcessManagerServer;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::{UnixListener, UnixStream};
@@ -19,36 +14,16 @@ use tower::service_fn;
 
 pub(super) struct McpTestHarness {
     pub client: DaemonClient,
-    process_manager: Arc<ProcessManager>,
-    root: PathBuf,
+    fixture: ProcessTestFixture,
     server_task: JoinHandle<()>,
 }
 
 impl McpTestHarness {
     pub async fn new() -> Self {
-        let root = PathBuf::from(format!("/tmp/mcp-{}", uuid::Uuid::new_v4()));
-        let socket_path = root.join("s");
-
-        let mut config = Config::default();
-        config.paths.data_dir = root.join("data");
-        config.paths.log_dir = root.join("log");
-        config.paths.socket_path = socket_path.clone();
-        config.paths.pid_file = root.join("pid");
-        config.paths.daemon_log_file = root.join("daemon.log");
-        config.process.restart.delay_ms = 0;
-        config.process.restart.process_stop_timeout_ms = 10_000;
-        config.ensure_directories().unwrap();
-
+        let fixture = ProcessTestFixture::new("mcp", 10_000);
+        let socket_path = fixture.socket_path();
         let listener = UnixListener::bind(&socket_path).unwrap();
-        let config = Arc::new(config);
-        let event_hub = Arc::new(StreamEventHub::new());
-        let log_hub = Arc::new(LogHub::with_event_hub(config.clone(), event_hub.clone()));
-        let process_manager = Arc::new(ProcessManager::with_event_hub(
-            config.clone(),
-            log_hub.clone(),
-            event_hub.clone(),
-        ));
-        let service = GrpcService::new(process_manager.clone(), log_hub, config, event_hub);
+        let service = fixture.grpc_service();
 
         let server_task = tokio::spawn(async move {
             Server::builder()
@@ -72,8 +47,7 @@ impl McpTestHarness {
 
         Self {
             client: DaemonClient::from_channel(channel),
-            process_manager,
-            root,
+            fixture,
             server_task,
         }
     }
@@ -97,39 +71,15 @@ impl McpTestHarness {
     }
 
     pub async fn cleanup(mut self) {
-        self.stop_all().await;
+        self.fixture.stop_all().await;
         self.server_task.abort();
         let _ = (&mut self.server_task).await;
-        std::fs::remove_dir_all(&self.root).unwrap();
-        self.root = PathBuf::new();
-    }
-
-    async fn stop_all(&self) {
-        for process in self.process_manager.get_all_processes() {
-            let stop = self
-                .process_manager
-                .stop_process(&process.id, Some(&process.project), true);
-            tokio::time::timeout(Duration::from_secs(15), stop)
-                .await
-                .expect("managed process stop exceeded cleanup deadline")
-                .expect("managed process cleanup failed");
-        }
+        self.fixture.remove_root();
     }
 }
 
 impl Drop for McpTestHarness {
     fn drop(&mut self) {
         self.server_task.abort();
-
-        #[cfg(unix)]
-        for process in self.process_manager.get_all_processes() {
-            unsafe {
-                libc::kill(-(process.pid as i32), libc::SIGKILL);
-            }
-        }
-
-        if !self.root.as_os_str().is_empty() {
-            let _ = std::fs::remove_dir_all(&self.root);
-        }
     }
 }

--- a/mcproc/src/cli/commands/mcp/tests.rs
+++ b/mcproc/src/cli/commands/mcp/tests.rs
@@ -1,0 +1,236 @@
+use super::test_support::McpTestHarness;
+use super::tools::{GrepTool, LogsTool, PsTool, RestartTool, StartTool, StatusTool, StopTool};
+use mcp_rs::{Error as McpError, ToolHandler};
+use serde_json::{json, Value};
+
+const PROJECT: &str = "mcp-tool-tests";
+
+async fn start_process(harness: &McpTestHarness, name: &str, command: &str) -> Value {
+    StartTool::new(harness.client.clone())
+        .handle(
+            Some(json!({
+                "name": name,
+                "cmd": command,
+                "project": PROJECT,
+            })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap()
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn all_tools_publish_nonempty_object_schemas_with_declared_required_fields() {
+    let harness = McpTestHarness::new().await;
+    let tools: Vec<(Box<dyn ToolHandler>, &[&str])> = vec![
+        (Box::new(StartTool::new(harness.client.clone())), &["name"]),
+        (Box::new(StopTool::new(harness.client.clone())), &["name"]),
+        (
+            Box::new(RestartTool::new(harness.client.clone())),
+            &["name"],
+        ),
+        (Box::new(PsTool::new(harness.client.clone())), &[]),
+        (Box::new(StatusTool::new(harness.client.clone())), &["name"]),
+        (Box::new(LogsTool::new(harness.client.clone())), &["name"]),
+        (
+            Box::new(GrepTool::new(harness.client.clone())),
+            &["pattern", "name"],
+        ),
+    ];
+
+    for (tool, expected_required) in tools {
+        let info = tool.tool_info();
+        assert!(!info.name.trim().is_empty());
+        assert!(!info.description.trim().is_empty(), "{}", info.name);
+        assert_eq!(info.input_schema["type"], "object", "{}", info.name);
+
+        let properties = info.input_schema["properties"]
+            .as_object()
+            .unwrap_or_else(|| panic!("{} schema must declare properties", info.name));
+        if !expected_required.is_empty() {
+            let required = info.input_schema["required"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{} schema must declare required", info.name));
+            for field in expected_required {
+                assert!(
+                    required.iter().any(|value| value == field),
+                    "{} must require {field}",
+                    info.name
+                );
+                assert!(
+                    properties.contains_key(*field),
+                    "{} required field {field} must exist in properties",
+                    info.name
+                );
+            }
+        }
+    }
+
+    harness.cleanup().await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn start_returns_process_identity_and_rejects_missing_command() {
+    let harness = McpTestHarness::new().await;
+    let started = start_process(&harness, "start-target", "echo hello-from-start; sleep 30").await;
+
+    assert_eq!(started["name"], "start-target");
+    assert!(started["status"].as_str().is_some());
+    assert!(started["pid"].as_u64().is_some_and(|pid| pid > 0));
+
+    let error = StartTool::new(harness.client.clone())
+        .handle(
+            Some(json!({ "name": "invalid-start", "project": PROJECT })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(error, McpError::InvalidParams(_)));
+    assert!(error.to_string().contains("either 'cmd' or 'args'"));
+
+    let stopped = StopTool::new(harness.client.clone())
+        .handle(
+            Some(json!({ "name": "start-target", "project": PROJECT })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stopped["success"], true);
+    harness.cleanup().await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn stop_reports_success_for_existing_process_and_false_for_missing_process() {
+    let harness = McpTestHarness::new().await;
+    start_process(&harness, "stop-target", "sleep 30").await;
+    let tool = StopTool::new(harness.client.clone());
+
+    let stopped = tool
+        .handle(
+            Some(json!({ "name": "stop-target", "project": PROJECT })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stopped["success"], true);
+
+    let missing = tool
+        .handle(
+            Some(json!({ "name": "not-present", "project": PROJECT })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing["success"], false);
+    assert!(missing["message"].as_str().unwrap().contains("not found"));
+    harness.cleanup().await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn restart_replaces_the_running_process_pid() {
+    let harness = McpTestHarness::new().await;
+    let started = start_process(&harness, "restart-target", "sleep 30").await;
+    let old_pid = started["pid"].as_u64().unwrap();
+
+    let restarted = RestartTool::new(harness.client.clone())
+        .handle(
+            Some(json!({ "name": "restart-target", "project": PROJECT })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(restarted["name"], "restart-target");
+    assert!(restarted["status"].as_str().is_some());
+    assert_ne!(restarted["pid"].as_u64().unwrap(), old_pid);
+    harness.cleanup().await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn ps_lists_the_started_process() {
+    let harness = McpTestHarness::new().await;
+    start_process(&harness, "ps-target", "sleep 30").await;
+
+    let response = PsTool::new(harness.client.clone())
+        .handle(Some(json!({})), McpTestHarness::context())
+        .await
+        .unwrap();
+    let processes = response["processes"].as_array().unwrap();
+    assert!(processes
+        .iter()
+        .any(|process| { process["name"] == "ps-target" && process["project"] == PROJECT }));
+    harness.cleanup().await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn status_returns_the_started_process_name_and_state() {
+    let harness = McpTestHarness::new().await;
+    start_process(&harness, "status-target", "sleep 30").await;
+
+    let response = StatusTool::new(harness.client.clone())
+        .handle(
+            Some(json!({ "name": "status-target", "project": PROJECT })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response["name"], "status-target");
+    assert!(response["status"].as_str().is_some());
+    harness.cleanup().await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn logs_and_grep_return_context_and_strip_ansi_sequences() {
+    let harness = McpTestHarness::new().await;
+    let started = start_process(
+        &harness,
+        "log-target",
+        "printf 'before-line\\n\\033[31mneedle-red\\033[0m\\nafter-line\\n'; sleep 30",
+    )
+    .await;
+    let log_file = started["log_file"].as_str().unwrap();
+    harness
+        .wait_for_log(log_file, &["before-line", "needle-red", "after-line"])
+        .await;
+
+    let logs = LogsTool::new(harness.client.clone())
+        .handle(
+            Some(json!({ "name": "log-target", "tail": 10, "project": PROJECT })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap();
+    let log_text = serde_json::to_string(&logs).unwrap();
+    assert!(log_text.contains("before-line"));
+    assert!(log_text.contains("needle-red"));
+    assert!(log_text.contains("after-line"));
+    assert!(!log_text.contains("\\u001b"));
+    assert!(!log_text.contains("[31m"));
+
+    let grep = GrepTool::new(harness.client.clone())
+        .handle(
+            Some(json!({
+                "name": "log-target",
+                "pattern": "needle-red",
+                "context": 1,
+                "project": PROJECT,
+            })),
+            McpTestHarness::context(),
+        )
+        .await
+        .unwrap();
+    let grep_text = serde_json::to_string(&grep).unwrap();
+    assert_eq!(grep["total_matches"], 1);
+    assert!(grep_text.contains("before-line"));
+    assert!(grep_text.contains("needle-red"));
+    assert!(grep_text.contains("after-line"));
+    assert!(!grep_text.contains("\\u001b"));
+    assert!(!grep_text.contains("[31m"));
+    harness.cleanup().await;
+}

--- a/mcproc/src/cli/commands/mcp/tests.rs
+++ b/mcproc/src/cli/commands/mcp/tests.rs
@@ -23,6 +23,18 @@ async fn start_process(harness: &McpTestHarness, name: &str, command: &str) -> V
 #[tokio::test]
 async fn all_tools_publish_nonempty_object_schemas_with_declared_required_fields() {
     let harness = McpTestHarness::new().await;
+    let start_info = StartTool::new(harness.client.clone()).tool_info();
+    let start_any_of = start_info.input_schema["anyOf"]
+        .as_array()
+        .expect("start_process schema must declare anyOf");
+    assert_eq!(start_any_of.len(), 2);
+    assert!(start_any_of
+        .iter()
+        .any(|alternative| alternative["required"] == json!(["cmd"])));
+    assert!(start_any_of
+        .iter()
+        .any(|alternative| alternative["required"] == json!(["args"])));
+
     let tools: Vec<(Box<dyn ToolHandler>, &[&str])> = vec![
         (Box::new(StartTool::new(harness.client.clone())), &["name"]),
         (Box::new(StopTool::new(harness.client.clone())), &["name"]),

--- a/mcproc/src/cli/commands/mcp/tools/start.rs
+++ b/mcproc/src/cli/commands/mcp/tools/start.rs
@@ -79,7 +79,11 @@ impl ToolHandler for StartTool {
                         "description": format!("Version management tool to use for executing the command. Supported tools: {}. When specified, the command will be executed through the tool (e.g., 'mise exec -- <command>'). This ensures proper PATH resolution for tool-managed environments.", crate::daemon::process::toolchain::Toolchain::all_supported())
                     }
                 },
-                "required": ["name"]
+                "required": ["name"],
+                "anyOf": [
+                    { "required": ["cmd"] },
+                    { "required": ["args"] }
+                ]
             }),
         }
     }

--- a/mcproc/src/client/mod.rs
+++ b/mcproc/src/client/mod.rs
@@ -7,6 +7,118 @@ use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 use tracing::warn;
 
+#[derive(Debug)]
+pub struct DaemonRestartedForUpgrade;
+
+impl std::fmt::Display for DaemonRestartedForUpgrade {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "daemon restarted for upgrade")
+    }
+}
+
+impl std::error::Error for DaemonRestartedForUpgrade {}
+
+fn pid_file_indicates_running(pid_file: &Path) -> bool {
+    let Ok(pid_string) = std::fs::read_to_string(pid_file) else {
+        return false;
+    };
+    let Ok(pid) = pid_string.trim().parse::<i32>() else {
+        return false;
+    };
+
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
+}
+
+async fn connect_channel(
+    socket_path: &Path,
+    connect_timeout: Duration,
+) -> Result<Channel, tonic::transport::Error> {
+    use hyper_util::rt::tokio::TokioIo;
+    use tokio::net::UnixStream;
+
+    const DUMMY_URI_FOR_UNIX_SOCKET: &str = "http://[::]:50051";
+    let socket_path = socket_path.to_path_buf();
+
+    Endpoint::from_static(DUMMY_URI_FOR_UNIX_SOCKET)
+        .connect_timeout(connect_timeout)
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let socket_path = socket_path.clone();
+            async move {
+                let stream = UnixStream::connect(socket_path).await?;
+                Ok::<_, std::io::Error>(TokioIo::new(stream))
+            }
+        }))
+        .await
+}
+
+async fn connect_with_retry(
+    socket_path: &Path,
+    attempts: u32,
+    interval: Duration,
+    connect_timeout: Duration,
+) -> Result<Channel, Box<dyn std::error::Error>> {
+    for attempt in 0..attempts {
+        if socket_path.exists() {
+            match connect_channel(socket_path, connect_timeout).await {
+                Ok(channel) => return Ok(channel),
+                Err(_) if attempt < attempts - 1 => {
+                    tokio::time::sleep(interval).await;
+                    continue;
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "Failed to connect to daemon after {} attempts: {}",
+                        attempts, error
+                    )
+                    .into());
+                }
+            }
+        }
+
+        tokio::time::sleep(interval).await;
+    }
+
+    Err("Failed to connect to daemon: socket not available".into())
+}
+
+fn spawn_daemon(config: &Config) -> Result<std::process::Child, Box<dyn std::error::Error>> {
+    let mcproc_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mcproc"));
+
+    let log_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(config.daemon_log_file())
+        .map_err(|error| format!("Failed to open daemon log file: {}", error))?;
+
+    let mut command = std::process::Command::new(&mcproc_path);
+    command.arg("--daemon");
+    command.stdin(std::process::Stdio::null()).stdout(
+        log_file
+            .try_clone()
+            .map_err(|error| format!("Failed to clone log file: {}", error))?,
+    );
+    command.stderr(log_file);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(|| {
+                nix::unistd::setsid()?;
+                Ok(())
+            });
+        }
+    }
+
+    command.spawn().map_err(|error| {
+        format!(
+            "Failed to start mcprocd daemon: {}. Please start it manually.",
+            error
+        )
+        .into()
+    })
+}
+
 #[derive(Clone)]
 pub struct DaemonClient {
     client: ProcessManagerClient<Channel>,
@@ -15,169 +127,10 @@ pub struct DaemonClient {
 impl DaemonClient {
     pub async fn connect(socket_path: Option<PathBuf>) -> Result<Self, Box<dyn std::error::Error>> {
         let config = Config::for_client();
-
         let socket_path = socket_path.unwrap_or(config.paths.socket_path.clone());
+        let daemon_running = pid_file_indicates_running(&config.paths.pid_file);
 
-        // Check if daemon is running by checking PID file
-        let daemon_running = if let Ok(pid_str) = std::fs::read_to_string(&config.paths.pid_file) {
-            if let Ok(pid) = pid_str.trim().parse::<i32>() {
-                // Check if process is actually running
-                nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-
-        if !daemon_running {
-            eprintln!("mcprocd daemon is not running. Starting it automatically...");
-
-            config.ensure_directories()?;
-
-            // Start daemon in background (use current binary with --daemon flag)
-            let mcproc_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mcproc"));
-
-            // Open log file for daemon output
-            let log_file = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(config.daemon_log_file())
-                .map_err(|e| format!("Failed to open daemon log file: {}", e))?;
-
-            let mut cmd = std::process::Command::new(&mcproc_path);
-            cmd.arg("--daemon");
-            cmd.stdin(std::process::Stdio::null())
-                .stdout(
-                    log_file
-                        .try_clone()
-                        .map_err(|e| format!("Failed to clone log file: {}", e))?,
-                )
-                .stderr(log_file);
-
-            // Detach from parent process
-            #[cfg(unix)]
-            {
-                use std::os::unix::process::CommandExt;
-                unsafe {
-                    cmd.pre_exec(|| {
-                        // Create new session
-                        nix::unistd::setsid()?;
-                        Ok(())
-                    });
-                }
-            }
-
-            match cmd.spawn() {
-                Ok(_) => {
-                    eprintln!("Started mcprocd daemon");
-                    eprintln!("Daemon logs: {}", config.daemon_log_file().display());
-
-                    // Wait for daemon to be ready by checking socket existence
-                    let max_attempts = 10;
-                    let check_interval = Duration::from_millis(100);
-                    let mut socket_ready = false;
-
-                    for i in 0..max_attempts {
-                        if socket_path.exists() {
-                            // Give it a tiny bit more time for the socket to be fully ready
-                            tokio::time::sleep(Duration::from_millis(50)).await;
-                            socket_ready = true;
-                            break;
-                        }
-                        tokio::time::sleep(check_interval).await;
-                        if i == max_attempts / 2 {
-                            eprintln!("Waiting for daemon to start...");
-                        }
-                    }
-
-                    if !socket_ready {
-                        eprintln!(
-                            "Warning: Daemon socket not found after {} attempts",
-                            max_attempts
-                        );
-                    }
-                }
-                Err(e) => {
-                    return Err(format!(
-                        "Failed to start mcprocd daemon: {}. Please start it manually.",
-                        e
-                    )
-                    .into());
-                }
-            }
-        }
-
-        // Connect to Unix socket with retry logic
-        #[cfg(unix)]
-        {
-            use hyper_util::rt::tokio::TokioIo;
-            use tokio::net::UnixStream;
-
-            // If we just started the daemon, wait for socket with retries
-            if !daemon_running {
-                let max_connection_attempts = 20; // 2 seconds total
-                let retry_interval = Duration::from_millis(100);
-                let connected = false;
-
-                for attempt in 0..max_connection_attempts {
-                    if socket_path.exists() {
-                        // Try to connect
-                        const DUMMY_URI_FOR_UNIX_SOCKET: &str = "http://[::]:50051";
-                        let socket_path_for_connector = socket_path.clone();
-
-                        match Endpoint::try_from(DUMMY_URI_FOR_UNIX_SOCKET)?
-                            .connect_timeout(Duration::from_secs(1))
-                            .connect_with_connector(service_fn(move |_: Uri| {
-                                let socket_path = socket_path_for_connector.clone();
-                                async move {
-                                    let stream = UnixStream::connect(&socket_path).await?;
-                                    Ok::<_, std::io::Error>(TokioIo::new(stream))
-                                }
-                            }))
-                            .await
-                        {
-                            Ok(ch) => {
-                                let channel = ch;
-                                let client = ProcessManagerClient::new(channel);
-                                let mut daemon_client = Self { client };
-
-                                // Check daemon version
-                                if let Err(e) = Self::check_and_restart_if_needed(
-                                    &mut daemon_client,
-                                    &socket_path,
-                                )
-                                .await
-                                {
-                                    warn!("Version check failed: {}", e);
-                                }
-
-                                return Ok(daemon_client);
-                            }
-                            Err(_) if attempt < max_connection_attempts - 1 => {
-                                // Retry
-                                tokio::time::sleep(retry_interval).await;
-                                continue;
-                            }
-                            Err(e) => {
-                                return Err(format!(
-                                    "Failed to connect to daemon after {} attempts: {}",
-                                    max_connection_attempts, e
-                                )
-                                .into());
-                            }
-                        }
-                    }
-
-                    tokio::time::sleep(retry_interval).await;
-                }
-
-                if !connected {
-                    return Err("Failed to connect to daemon: socket not available".into());
-                }
-            }
-
-            // Normal connection attempt (daemon was already running)
+        let channel = if daemon_running {
             if !socket_path.exists() {
                 return Err(format!(
                     "Unix socket not found at {:?}. Is mcprocd running?",
@@ -186,38 +139,69 @@ impl DaemonClient {
                 .into());
             }
 
-            const DUMMY_URI_FOR_UNIX_SOCKET: &str = "http://[::]:50051";
-            let socket_path_for_connector = socket_path.clone();
-            let channel = Endpoint::try_from(DUMMY_URI_FOR_UNIX_SOCKET)?
-                .connect_timeout(Duration::from_secs(
-                    config.daemon.client_connection_timeout_secs,
-                ))
-                .connect_with_connector(service_fn(move |_: Uri| {
-                    let socket_path = socket_path_for_connector.clone();
-                    async move {
-                        let stream = UnixStream::connect(&socket_path).await?;
-                        Ok::<_, std::io::Error>(TokioIo::new(stream))
-                    }
-                }))
-                .await?;
+            connect_channel(
+                &socket_path,
+                Duration::from_secs(config.daemon.client_connection_timeout_secs),
+            )
+            .await?
+        } else {
+            eprintln!("mcprocd daemon is not running. Starting it automatically...");
 
-            let client = ProcessManagerClient::new(channel);
+            config.ensure_directories()?;
+            spawn_daemon(&config)?;
 
-            let mut daemon_client = Self { client };
+            eprintln!("Started mcprocd daemon");
+            eprintln!("Daemon logs: {}", config.daemon_log_file().display());
 
-            // Check daemon version and restart if needed
-            if let Err(e) =
-                Self::check_and_restart_if_needed(&mut daemon_client, &socket_path).await
-            {
-                warn!("Version check failed: {}", e);
+            let max_attempts = 10;
+            let check_interval = Duration::from_millis(100);
+            let mut socket_ready = false;
+
+            for attempt in 0..max_attempts {
+                if socket_path.exists() {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    socket_ready = true;
+                    break;
+                }
+                tokio::time::sleep(check_interval).await;
+                if attempt == max_attempts / 2 {
+                    eprintln!("Waiting for daemon to start...");
+                }
             }
 
-            Ok(daemon_client)
+            if !socket_ready {
+                eprintln!(
+                    "Warning: Daemon socket not found after {} attempts",
+                    max_attempts
+                );
+            }
+
+            connect_with_retry(
+                &socket_path,
+                20,
+                Duration::from_millis(100),
+                Duration::from_secs(1),
+            )
+            .await?
+        };
+
+        let mut daemon_client = Self::from_channel(channel);
+
+        if let Err(error) =
+            Self::check_and_restart_if_needed(&mut daemon_client, &socket_path).await
+        {
+            if error.downcast_ref::<DaemonRestartedForUpgrade>().is_some() {
+                return Err(error);
+            }
+            warn!("Version check failed: {}", error);
         }
 
-        #[cfg(not(unix))]
-        {
-            return Err("Unix sockets are not supported on this platform".into());
+        Ok(daemon_client)
+    }
+
+    pub fn from_channel(channel: Channel) -> Self {
+        Self {
+            client: ProcessManagerClient::new(channel),
         }
     }
 
@@ -236,7 +220,6 @@ impl DaemonClient {
                     );
                     eprintln!("Restarting daemon to update version...");
 
-                    // Use daemon restart command
                     let mcproc_path =
                         std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mcproc"));
 
@@ -250,13 +233,11 @@ impl DaemonClient {
                         return Err(format!("Failed to restart daemon: {}", stderr).into());
                     }
 
-                    eprintln!("Daemon restarted successfully. Please run your command again.");
-                    std::process::exit(0);
+                    return Err(DaemonRestartedForUpgrade.into());
                 }
             }
-            Err(e) => {
-                // If we can't get status, log warning but continue
-                warn!("Could not verify daemon version: {}", e);
+            Err(error) => {
+                warn!("Could not verify daemon version: {}", error);
             }
         }
         Ok(())
@@ -264,5 +245,137 @@ impl DaemonClient {
 
     pub fn inner(&mut self) -> &mut ProcessManagerClient<Channel> {
         &mut self.client
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::pending;
+    use std::process::{Command, Stdio};
+    use tokio::net::UnixListener;
+    use uuid::Uuid;
+
+    fn temporary_path(name: &str) -> (tempfile::TempDir, PathBuf) {
+        let prefix = format!("mcproc-client-{}-", Uuid::new_v4());
+        let directory = tempfile::Builder::new()
+            .prefix(&prefix)
+            .tempdir_in("/tmp")
+            .unwrap();
+        let path = directory.path().join(name);
+        (directory, path)
+    }
+
+    fn spawn_accept_loop(listener: UnixListener) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _stream = stream;
+                    pending::<()>().await;
+                });
+            }
+        })
+    }
+
+    #[test]
+    fn missing_pid_file_does_not_indicate_running() {
+        let (_directory, pid_file) = temporary_path("missing.pid");
+
+        assert!(!pid_file_indicates_running(&pid_file));
+    }
+
+    #[test]
+    fn invalid_pid_file_does_not_indicate_running() {
+        let (_directory, pid_file) = temporary_path("invalid.pid");
+        std::fs::write(&pid_file, "abc").unwrap();
+
+        assert!(!pid_file_indicates_running(&pid_file));
+    }
+
+    #[test]
+    fn dead_process_pid_file_does_not_indicate_running() {
+        let (_directory, pid_file) = temporary_path("dead.pid");
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        child.kill().unwrap();
+        child.wait().unwrap();
+        std::fs::write(&pid_file, pid.to_string()).unwrap();
+
+        assert!(!pid_file_indicates_running(&pid_file));
+    }
+
+    #[test]
+    fn live_process_pid_file_indicates_running() {
+        let (_directory, pid_file) = temporary_path("live.pid");
+        std::fs::write(&pid_file, std::process::id().to_string()).unwrap();
+
+        assert!(pid_file_indicates_running(&pid_file));
+    }
+
+    #[tokio::test]
+    async fn connect_channel_connects_to_unix_listener() {
+        let (_directory, socket_path) = temporary_path("daemon.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let accept_task = spawn_accept_loop(listener);
+
+        let result = connect_channel(&socket_path, Duration::from_secs(2)).await;
+
+        accept_task.abort();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn connect_channel_fails_for_missing_socket() {
+        let (_directory, socket_path) = temporary_path("missing.sock");
+
+        let result = connect_channel(&socket_path, Duration::from_secs(2)).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn connect_with_retry_connects_when_listener_is_ready() {
+        let (_directory, socket_path) = temporary_path("retry.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let accept_task = spawn_accept_loop(listener);
+
+        let result = connect_with_retry(
+            &socket_path,
+            50,
+            Duration::from_millis(100),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        accept_task.abort();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn connect_with_retry_fails_after_configured_attempts() {
+        let (_directory, socket_path) = temporary_path("never-created.sock");
+
+        let result = connect_with_retry(
+            &socket_path,
+            3,
+            Duration::from_millis(10),
+            Duration::from_millis(100),
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn daemon_restarted_for_upgrade_is_downcastable_error() {
+        let error: Box<dyn std::error::Error> = Box::new(DaemonRestartedForUpgrade);
+
+        assert!(error.downcast_ref::<DaemonRestartedForUpgrade>().is_some());
     }
 }

--- a/mcproc/src/client/mod.rs
+++ b/mcproc/src/client/mod.rs
@@ -152,29 +152,7 @@ impl DaemonClient {
 
             eprintln!("Started mcprocd daemon");
             eprintln!("Daemon logs: {}", config.daemon_log_file().display());
-
-            let max_attempts = 10;
-            let check_interval = Duration::from_millis(100);
-            let mut socket_ready = false;
-
-            for attempt in 0..max_attempts {
-                if socket_path.exists() {
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                    socket_ready = true;
-                    break;
-                }
-                tokio::time::sleep(check_interval).await;
-                if attempt == max_attempts / 2 {
-                    eprintln!("Waiting for daemon to start...");
-                }
-            }
-
-            if !socket_ready {
-                eprintln!(
-                    "Warning: Daemon socket not found after {} attempts",
-                    max_attempts
-                );
-            }
+            eprintln!("Waiting for daemon to start...");
 
             connect_with_retry(
                 &socket_path,
@@ -187,9 +165,7 @@ impl DaemonClient {
 
         let mut daemon_client = Self::from_channel(channel);
 
-        if let Err(error) =
-            Self::check_and_restart_if_needed(&mut daemon_client, &socket_path).await
-        {
+        if let Err(error) = daemon_client.check_and_restart_if_needed().await {
             if error.downcast_ref::<DaemonRestartedForUpgrade>().is_some() {
                 return Err(error);
             }
@@ -205,12 +181,9 @@ impl DaemonClient {
         }
     }
 
-    async fn check_and_restart_if_needed(
-        client: &mut Self,
-        _socket_path: &Path,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    async fn check_and_restart_if_needed(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let request = proto::GetDaemonStatusRequest {};
-        match client.inner().get_daemon_status(request).await {
+        match self.inner().get_daemon_status(request).await {
             Ok(response) => {
                 let status = response.into_inner();
                 if status.version != VERSION {
@@ -354,6 +327,33 @@ mod tests {
         .await;
 
         accept_task.abort();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn connect_with_retry_connects_when_listener_binds_later() {
+        let (_directory, socket_path) = temporary_path("delayed-retry.sock");
+        let listener_path = socket_path.clone();
+        let listener_task = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let listener = UnixListener::bind(listener_path).unwrap();
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _stream = stream;
+                    pending::<()>().await;
+                });
+            }
+        });
+
+        let result = connect_with_retry(
+            &socket_path,
+            50,
+            Duration::from_millis(100),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        listener_task.abort();
         assert!(result.is_ok());
     }
 

--- a/mcproc/src/daemon/api/grpc/helpers.rs
+++ b/mcproc/src/daemon/api/grpc/helpers.rs
@@ -174,3 +174,66 @@ pub fn create_failed_process_info(params: FailedProcessParams) -> ProcessInfo {
         matched_line: None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::create_process_info;
+    use crate::daemon::process::proxy::{ProcessStatus, ProxyInfo};
+    use crate::daemon::process::types::ProxyInfoParams;
+    use std::path::Path;
+
+    #[test]
+    fn grpc_rpc_create_process_info_maps_proxy_fields_for_every_status_and_detected_port_state() {
+        let statuses = [
+            ProcessStatus::Starting,
+            ProcessStatus::Running,
+            ProcessStatus::Stopping,
+            ProcessStatus::Stopped,
+            ProcessStatus::Failed,
+        ];
+
+        for status in statuses {
+            for detected_port in [None, Some(4321)] {
+                let process = ProxyInfo::new(ProxyInfoParams {
+                    id: format!("id-{status:?}-{detected_port:?}"),
+                    name: "worker".to_string(),
+                    project: "alpha".to_string(),
+                    cmd: Some("sleep 30".to_string()),
+                    args: vec![],
+                    cwd: Some("/tmp/work".into()),
+                    env: None,
+                    wait_for_log: None,
+                    wait_timeout: None,
+                    toolchain: None,
+                    pid: 1234,
+                });
+                process.set_status(status);
+                process.update_detected_port(&detected_port.into_iter().collect::<Vec<_>>());
+
+                let info = create_process_info(
+                    &process,
+                    Path::new("/tmp/mcproc-logs"),
+                    None,
+                    vec![],
+                    None,
+                );
+
+                assert_eq!(info.id, process.id);
+                assert_eq!(info.name, "worker");
+                assert_eq!(info.project, "alpha");
+                assert_eq!(info.cmd, "sleep 30");
+                assert_eq!(info.cwd, "/tmp/work");
+                assert_eq!(info.pid, Some(1234));
+                assert_eq!(info.status, proto::ProcessStatus::from(status) as i32);
+                assert_eq!(info.ports, detected_port.into_iter().collect::<Vec<_>>());
+                assert_eq!(info.log_file, "/tmp/mcproc-logs/alpha/worker.log");
+                let start_time = info.start_time.unwrap();
+                assert_eq!(start_time.seconds, process.start_time.timestamp());
+                assert_eq!(
+                    start_time.nanos,
+                    process.start_time.timestamp_subsec_nanos() as i32
+                );
+            }
+        }
+    }
+}

--- a/mcproc/src/daemon/api/grpc/log_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/log_handlers.rs
@@ -710,11 +710,66 @@ mod tests {
     };
     use crate::common::config::Config;
     use crate::common::process_key::ProcessKey;
+    use crate::daemon::api::grpc::test_support::TestHarness;
     use crate::daemon::log::LogHub;
-    use crate::daemon::stream::StreamEventHub;
-    use chrono::{Local, TimeZone};
+    use crate::daemon::process::event::ProcessEvent;
+    use crate::daemon::stream::{StreamEvent, StreamEventHub};
+    use chrono::{Local, TimeZone, Utc};
+    use proto::{get_logs_response, GetLogsRequest, GrepLogsRequest};
     use std::sync::Arc;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use tokio_stream::StreamExt;
+    use tonic::{Code, Request};
+
+    fn log_path(harness: &TestHarness, project: &str, name: &str) -> std::path::PathBuf {
+        harness
+            .service
+            .config
+            .paths
+            .log_dir
+            .join(project)
+            .join(format!("{name}.log"))
+    }
+
+    fn write_log(harness: &TestHarness, project: &str, name: &str, contents: &str) {
+        let path = log_path(harness, project, name);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn get_logs_request(project: &str, name: &str) -> GetLogsRequest {
+        GetLogsRequest {
+            process_names: vec![name.to_string()],
+            tail: Some(0),
+            follow: Some(false),
+            project: project.to_string(),
+            include_events: Some(false),
+        }
+    }
+
+    fn grep_logs_request(project: &str, name: &str, pattern: &str) -> GrepLogsRequest {
+        GrepLogsRequest {
+            name: name.to_string(),
+            pattern: pattern.to_string(),
+            project: project.to_string(),
+            context: Some(0),
+            before: None,
+            after: None,
+            since: None,
+            until: None,
+            last: None,
+        }
+    }
+
+    async fn next_follow_response(
+        mut stream: <super::GrpcService as proto::process_manager_server::ProcessManager>::GetLogsStream,
+    ) -> proto::GetLogsResponse {
+        tokio::time::timeout(Duration::from_secs(10), stream.next())
+            .await
+            .expect("follow stream exceeded deadline")
+            .expect("follow stream ended before yielding a response")
+            .expect("follow stream returned an error")
+    }
 
     #[test]
     fn grep_log_path_rejects_traversal_and_stays_under_log_dir() {
@@ -869,5 +924,276 @@ mod tests {
             .with_timezone(&chrono::Utc);
 
         assert_eq!(parse_time_string("2026-01-01 12:00").unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn added_log_tests_get_logs_tails_unregistered_process_file() {
+        let harness = TestHarness::new();
+        let contents = (1..=10)
+            .map(|line| format!("2025-07-15T03:13:{line:02}.375+00:00 [INFO] line {line}\n"))
+            .collect::<String>();
+        write_log(&harness, "alpha", "worker", &contents);
+        let mut request = get_logs_request("alpha", "worker");
+        request.tail = Some(10);
+
+        let mut stream = harness
+            .service
+            .get_logs_impl(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        let mut responses = Vec::new();
+        while let Some(response) = stream.next().await {
+            responses.push(response.unwrap());
+        }
+
+        assert_eq!(responses.len(), 10);
+        for (offset, response) in responses.into_iter().enumerate() {
+            let Some(get_logs_response::Content::LogEntry(entry)) = response.content else {
+                panic!("expected log entry response");
+            };
+            let expected_line = offset + 1;
+            assert_eq!(entry.content, format!("line {expected_line}"));
+            assert_eq!(entry.line_number, expected_line as u32);
+            assert_eq!(entry.process_name.as_deref(), Some("worker"));
+        }
+        harness.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn added_log_tests_get_logs_handles_zero_tail_empty_and_missing_files() {
+        let harness = TestHarness::new();
+        write_log(
+            &harness,
+            "alpha",
+            "nonempty",
+            "2025-07-15T03:13:12.375+00:00 [INFO] hidden\n",
+        );
+        write_log(&harness, "alpha", "empty", "");
+
+        for (name, tail) in [("nonempty", 0), ("empty", 10), ("missing", 10)] {
+            let mut request = get_logs_request("alpha", name);
+            request.tail = Some(tail);
+            let mut stream = harness
+                .service
+                .get_logs_impl(Request::new(request))
+                .await
+                .unwrap()
+                .into_inner();
+            let mut responses = Vec::new();
+            while let Some(response) = stream.next().await {
+                responses.push(response.unwrap());
+            }
+            assert!(responses.is_empty(), "{name} unexpectedly returned logs");
+        }
+        harness.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn added_log_tests_get_logs_follow_filters_project_and_receives_log_hub_event() {
+        let harness = TestHarness::new();
+        let mut request = get_logs_request("alpha", "worker");
+        request.follow = Some(true);
+        let stream = harness
+            .service
+            .get_logs_impl(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        let reader = tokio::spawn(next_follow_response(stream));
+
+        harness.service.log_hub.publish_log_event(
+            &ProcessKey::new("other-project", "worker"),
+            "wrong project",
+            false,
+        );
+        harness.service.log_hub.publish_log_event(
+            &ProcessKey::new("alpha", "worker"),
+            "expected log",
+            false,
+        );
+
+        let response = reader.await.unwrap();
+        let Some(get_logs_response::Content::LogEntry(entry)) = response.content else {
+            panic!("expected log entry response");
+        };
+        assert_eq!(entry.content, "expected log");
+        assert_eq!(entry.process_name.as_deref(), Some("worker"));
+        harness.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn added_log_tests_get_logs_include_events_controls_process_events() {
+        let harness = TestHarness::new();
+        let process_event = || ProcessEvent::Started {
+            process_id: "process-id".to_string(),
+            name: "worker".to_string(),
+            project: "alpha".to_string(),
+            pid: 42,
+        };
+
+        let mut included_request = get_logs_request("alpha", "worker");
+        included_request.follow = Some(true);
+        included_request.include_events = Some(true);
+        let included_stream = harness
+            .service
+            .get_logs_impl(Request::new(included_request))
+            .await
+            .unwrap()
+            .into_inner();
+        let included_reader = tokio::spawn(next_follow_response(included_stream));
+        harness
+            .service
+            .event_hub
+            .publish(StreamEvent::Process(process_event()));
+
+        let included_response = included_reader.await.unwrap();
+        let Some(get_logs_response::Content::Event(event)) = included_response.content else {
+            panic!("expected lifecycle event response");
+        };
+        assert_eq!(event.process_id, "process-id");
+        assert_eq!(event.name, "worker");
+        assert_eq!(event.project, "alpha");
+        assert_eq!(event.pid, Some(42));
+
+        let mut excluded_request = get_logs_request("alpha", "worker");
+        excluded_request.follow = Some(true);
+        let excluded_stream = harness
+            .service
+            .get_logs_impl(Request::new(excluded_request))
+            .await
+            .unwrap()
+            .into_inner();
+        let excluded_reader = tokio::spawn(next_follow_response(excluded_stream));
+        harness
+            .service
+            .event_hub
+            .publish(StreamEvent::Process(process_event()));
+        harness.service.log_hub.publish_log_event(
+            &ProcessKey::new("alpha", "worker"),
+            "event was filtered",
+            false,
+        );
+
+        let excluded_response = excluded_reader.await.unwrap();
+        let Some(get_logs_response::Content::LogEntry(entry)) = excluded_response.content else {
+            panic!("process event must be excluded when include_events is false");
+        };
+        assert_eq!(entry.content, "event was filtered");
+        harness.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn added_log_tests_grep_logs_returns_match_with_before_and_after_context() {
+        let harness = TestHarness::new();
+        write_log(
+            &harness,
+            "alpha",
+            "worker",
+            concat!(
+                "2025-07-15T03:13:10.375+00:00 [INFO] first\n",
+                "2025-07-15T03:13:11.375+00:00 [INFO] before\n",
+                "2025-07-15T03:13:12.375+00:00 [ERROR] needle\n",
+                "2025-07-15T03:13:13.375+00:00 [INFO] after\n",
+                "2025-07-15T03:13:14.375+00:00 [INFO] last\n",
+            ),
+        );
+        let mut request = grep_logs_request("alpha", "worker", "needle");
+        request.before = Some(1);
+        request.after = Some(1);
+
+        let response = harness
+            .service
+            .grep_logs_impl(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.matches.len(), 1);
+        let grep_match = &response.matches[0];
+        let matched = grep_match.matched_line.as_ref().unwrap();
+        assert_eq!(matched.content, "needle");
+        assert_eq!(matched.line_number, 3);
+        assert_eq!(grep_match.context_before.len(), 1);
+        assert_eq!(grep_match.context_before[0].content, "before");
+        assert_eq!(grep_match.context_before[0].line_number, 2);
+        assert_eq!(grep_match.context_after.len(), 1);
+        assert_eq!(grep_match.context_after[0].content, "after");
+        assert_eq!(grep_match.context_after[0].line_number, 4);
+        harness.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn added_log_tests_grep_logs_rejects_invalid_regex() {
+        let harness = TestHarness::new();
+        write_log(&harness, "alpha", "worker", "log line\n");
+
+        let error = harness
+            .service
+            .grep_logs_impl(Request::new(grep_logs_request("alpha", "worker", "[")))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), Code::InvalidArgument);
+        harness.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn added_log_tests_grep_logs_missing_file_is_not_found() {
+        let harness = TestHarness::new();
+
+        let error = harness
+            .service
+            .grep_logs_impl(Request::new(grep_logs_request(
+                "alpha", "missing", "needle",
+            )))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), Code::NotFound);
+        harness.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn added_log_tests_grep_logs_filters_since_and_until_using_local_input() {
+        let harness = TestHarness::new();
+        write_log(
+            &harness,
+            "alpha",
+            "worker",
+            concat!(
+                "2025-07-15T03:13:10.375+00:00 [INFO] needle past\n",
+                "2025-07-15T03:13:12.375+00:00 [INFO] needle target\n",
+                "2025-07-15T03:13:14.375+00:00 [INFO] needle future\n",
+            ),
+        );
+        let since_utc = Utc.with_ymd_and_hms(2025, 7, 15, 3, 13, 11).unwrap();
+        let until_utc = Utc.with_ymd_and_hms(2025, 7, 15, 3, 13, 13).unwrap();
+        let mut request = grep_logs_request("alpha", "worker", "needle");
+        request.since = Some(
+            since_utc
+                .with_timezone(&Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string(),
+        );
+        request.until = Some(
+            until_utc
+                .with_timezone(&Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string(),
+        );
+
+        let response = harness
+            .service
+            .grep_logs_impl(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.matches.len(), 1);
+        let matched = response.matches[0].matched_line.as_ref().unwrap();
+        assert_eq!(matched.content, "needle target");
+        assert_eq!(matched.line_number, 2);
+        harness.cleanup().await;
     }
 }

--- a/mcproc/src/daemon/api/grpc/mod.rs
+++ b/mcproc/src/daemon/api/grpc/mod.rs
@@ -5,4 +5,7 @@ pub mod process_handlers;
 pub mod server;
 pub mod service;
 
+#[cfg(test)]
+mod test_support;
+
 pub use server::start_grpc_server;

--- a/mcproc/src/daemon/api/grpc/process_handlers.rs
+++ b/mcproc/src/daemon/api/grpc/process_handlers.rs
@@ -370,8 +370,13 @@ mod tests {
         force_restart_stop_result, matches_status_filter, validate_status_filter,
         validate_wait_timeout,
     };
+    use crate::daemon::api::grpc::test_support::{process_from_restart_stream, TestHarness};
     use crate::daemon::error::McprocdError;
     use crate::daemon::process::ProcessStatus;
+    use proto::{
+        GetProcessRequest, ListProcessesRequest, RestartProcessRequest, StopProcessRequest,
+    };
+    use tonic::{Code, Request};
 
     #[test]
     fn status_filter_selects_only_requested_status() {
@@ -406,5 +411,238 @@ mod tests {
         let result =
             force_restart_stop_result(Err(McprocdError::StopError("cannot stop".to_string())));
         assert_eq!(result.unwrap_err().code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_start_process_returns_running_process_info() {
+        let harness = TestHarness::new();
+        let process = harness.start("worker", "alpha").await.unwrap();
+        harness.cleanup().await;
+
+        assert_eq!(process.name, "worker");
+        assert_eq!(process.project, "alpha");
+        assert!(process.pid.is_some_and(|pid| pid > 0));
+        assert!(matches!(
+            proto::ProcessStatus::try_from(process.status).unwrap(),
+            proto::ProcessStatus::Starting | proto::ProcessStatus::Running
+        ));
+    }
+
+    #[tokio::test]
+    async fn grpc_rpc_start_process_rejects_invalid_process_name() {
+        let harness = TestHarness::new();
+        let mut request = TestHarness::start_request("a/b", "alpha");
+        request.args.clear();
+        let result = harness
+            .service
+            .start_process_impl(Request::new(request))
+            .await;
+        harness.cleanup().await;
+
+        assert_eq!(result.err().unwrap().code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn grpc_rpc_start_process_rejects_wait_timeout_over_one_hour() {
+        let harness = TestHarness::new();
+        let mut request = TestHarness::start_request("worker", "alpha");
+        request.wait_timeout = Some(3601);
+        let result = harness
+            .service
+            .start_process_impl(Request::new(request))
+            .await;
+        harness.cleanup().await;
+
+        assert_eq!(result.err().unwrap().code(), Code::InvalidArgument);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_start_process_rejects_duplicate_name_in_project() {
+        let harness = TestHarness::new();
+        harness.start("worker", "alpha").await.unwrap();
+        let duplicate = harness.start("worker", "alpha").await;
+        harness.cleanup().await;
+
+        assert_eq!(duplicate.unwrap_err().code(), Code::AlreadyExists);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_start_process_reports_missing_command_as_failed_process() {
+        let harness = TestHarness::new();
+        let mut request = TestHarness::start_request("missing-command", "alpha");
+        request.args.clear();
+        request.cmd = Some("definitely-not-a-command-xyz".to_string());
+        let process = harness.start_with_request(request).await.unwrap();
+        harness.cleanup().await;
+
+        assert_eq!(
+            process.status,
+            proto::ProcessStatus::Failed as i32,
+            "a command lookup failure must be represented in ProcessInfo"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_start_process_force_restart_replaces_running_process() {
+        let harness = TestHarness::new();
+        let first = harness.start("worker", "alpha").await.unwrap();
+        let mut request = TestHarness::start_request("worker", "alpha");
+        request.force_restart = Some(true);
+        let replacement = harness.start_with_request(request).await.unwrap();
+        harness.cleanup().await;
+
+        assert_ne!(first.pid, replacement.pid);
+        assert_eq!(replacement.status, proto::ProcessStatus::Running as i32);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_stop_process_handles_existing_and_missing_processes() {
+        let harness = TestHarness::new();
+        harness.start("worker", "alpha").await.unwrap();
+        let stopped = harness
+            .service
+            .stop_process_impl(Request::new(StopProcessRequest {
+                name: "worker".to_string(),
+                project: "alpha".to_string(),
+                force: Some(true),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        let removed = harness
+            .service
+            .process_manager
+            .get_process_by_name_or_id_with_project("worker", Some("alpha"))
+            .is_none();
+        let missing = harness
+            .service
+            .stop_process_impl(Request::new(StopProcessRequest {
+                name: "absent".to_string(),
+                project: "alpha".to_string(),
+                force: Some(true),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        harness.cleanup().await;
+
+        assert!(stopped.success);
+        assert!(removed);
+        assert!(!missing.success);
+        assert!(missing.message.unwrap().contains("not found"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_restart_process_replaces_pid_and_missing_process_is_not_found() {
+        let harness = TestHarness::new();
+        let first = harness.start("worker", "alpha").await.unwrap();
+        let response = harness
+            .service
+            .restart_process_impl(Request::new(RestartProcessRequest {
+                name: "worker".to_string(),
+                project: "alpha".to_string(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+        let restarted = process_from_restart_stream(response.into_inner())
+            .await
+            .unwrap();
+        let missing_response = harness
+            .service
+            .restart_process_impl(Request::new(RestartProcessRequest {
+                name: "absent".to_string(),
+                project: "alpha".to_string(),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+        let missing = process_from_restart_stream(missing_response.into_inner()).await;
+        harness.cleanup().await;
+
+        assert_ne!(first.pid, restarted.pid);
+        assert_eq!(restarted.status, proto::ProcessStatus::Running as i32);
+        assert_eq!(missing.unwrap_err().code(), Code::NotFound);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_get_process_returns_metadata_and_not_found() {
+        let harness = TestHarness::new();
+        let started = harness.start("worker", "alpha").await.unwrap();
+        let found = harness
+            .service
+            .get_process_impl(Request::new(GetProcessRequest {
+                name: "worker".to_string(),
+                project: "alpha".to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .process
+            .unwrap();
+        let missing = harness
+            .service
+            .get_process_impl(Request::new(GetProcessRequest {
+                name: "absent".to_string(),
+                project: "alpha".to_string(),
+            }))
+            .await;
+        harness.cleanup().await;
+
+        assert_eq!(found.name, "worker");
+        assert_eq!(found.project, "alpha");
+        assert_eq!(found.pid, started.pid);
+        assert_eq!(found.status, proto::ProcessStatus::Running as i32);
+        assert_eq!(missing.unwrap_err().code(), Code::NotFound);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_list_processes_applies_project_and_status_filters() {
+        let harness = TestHarness::new();
+        harness.start("alpha-worker", "alpha").await.unwrap();
+        harness.start("beta-worker", "beta").await.unwrap();
+        let by_project = harness
+            .service
+            .list_processes_impl(Request::new(ListProcessesRequest {
+                project_filter: Some("alpha".to_string()),
+                ..Default::default()
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        let running = harness
+            .service
+            .list_processes_impl(Request::new(ListProcessesRequest {
+                status_filter: Some(proto::ProcessStatus::Running as i32),
+                ..Default::default()
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        let invalid = harness
+            .service
+            .list_processes_impl(Request::new(ListProcessesRequest {
+                status_filter: Some(999),
+                ..Default::default()
+            }))
+            .await;
+        harness.cleanup().await;
+
+        assert_eq!(by_project.processes.len(), 1);
+        assert_eq!(by_project.processes[0].project, "alpha");
+        assert_eq!(running.processes.len(), 2);
+        assert!(running
+            .processes
+            .iter()
+            .all(|process| process.status == proto::ProcessStatus::Running as i32));
+        assert_eq!(invalid.unwrap_err().code(), Code::InvalidArgument);
     }
 }

--- a/mcproc/src/daemon/api/grpc/service.rs
+++ b/mcproc/src/daemon/api/grpc/service.rs
@@ -128,11 +128,62 @@ impl GrpcService {
 #[cfg(test)]
 mod tests {
     use super::uptime_seconds;
+    use crate::daemon::api::grpc::test_support::TestHarness;
     use chrono::{Duration, Utc};
+    use proto::{CleanProjectRequest, GetDaemonStatusRequest};
+    use tonic::Request;
 
     #[test]
     fn uptime_is_zero_when_clock_moves_backwards() {
         let now = Utc::now();
         assert_eq!(uptime_seconds(now, now + Duration::seconds(10)), 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_clean_project_stops_every_process_and_returns_names() {
+        let harness = TestHarness::new();
+        harness.start("worker-one", "alpha").await.unwrap();
+        harness.start("worker-two", "alpha").await.unwrap();
+        let response = harness
+            .service
+            .clean_project_impl(Request::new(CleanProjectRequest {
+                project: Some("alpha".to_string()),
+                force: true,
+                ..Default::default()
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        let registry_empty = harness
+            .service
+            .process_manager
+            .get_all_processes()
+            .is_empty();
+        harness.cleanup().await;
+
+        assert_eq!(response.processes_stopped, 2);
+        let mut names = response.stopped_process_names;
+        names.sort();
+        assert_eq!(names, ["worker-one", "worker-two"]);
+        assert!(registry_empty);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grpc_rpc_daemon_status_reports_current_pid_and_active_process_count() {
+        let harness = TestHarness::new();
+        harness.start("worker-one", "alpha").await.unwrap();
+        harness.start("worker-two", "beta").await.unwrap();
+        let response = harness
+            .service
+            .get_daemon_status_impl(Request::new(GetDaemonStatusRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        harness.cleanup().await;
+
+        assert_eq!(response.pid, std::process::id());
+        assert_eq!(response.active_processes, 2);
     }
 }

--- a/mcproc/src/daemon/api/grpc/test_support.rs
+++ b/mcproc/src/daemon/api/grpc/test_support.rs
@@ -1,0 +1,139 @@
+use super::service::GrpcService;
+use crate::common::config::Config;
+use crate::daemon::log::LogHub;
+use crate::daemon::process::ProcessManager;
+use crate::daemon::stream::StreamEventHub;
+use proto::{
+    restart_process_response, start_process_response, ProcessInfo, RestartProcessResponse,
+    StartProcessRequest, StartProcessResponse,
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_stream::StreamExt;
+use tonic::{Code, Request, Status};
+
+pub(super) struct TestHarness {
+    pub service: GrpcService,
+    root: PathBuf,
+}
+
+impl TestHarness {
+    pub fn new() -> Self {
+        let root = std::env::temp_dir().join(format!("mcproc-grpc-test-{}", uuid::Uuid::new_v4()));
+        let mut config = Config::default();
+        config.paths.data_dir = root.join("data");
+        config.paths.log_dir = root.join("log");
+        config.paths.socket_path = root.join("runtime/mcprocd.sock");
+        config.paths.pid_file = root.join("runtime/mcprocd.pid");
+        config.paths.daemon_log_file = root.join("state/mcprocd.log");
+        config.process.restart.delay_ms = 0;
+        config.process.restart.process_stop_timeout_ms = 10_000;
+
+        std::fs::create_dir_all(&config.paths.data_dir).unwrap();
+        std::fs::create_dir_all(&config.paths.log_dir).unwrap();
+        std::fs::create_dir_all(config.paths.socket_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(config.paths.daemon_log_file.parent().unwrap()).unwrap();
+
+        let config = Arc::new(config);
+        let event_hub = Arc::new(StreamEventHub::new());
+        let log_hub = Arc::new(LogHub::with_event_hub(config.clone(), event_hub.clone()));
+        let process_manager = Arc::new(ProcessManager::with_event_hub(
+            config.clone(),
+            log_hub.clone(),
+            event_hub.clone(),
+        ));
+        let service = GrpcService::new(process_manager, log_hub, config, event_hub);
+
+        Self { service, root }
+    }
+
+    pub fn start_request(name: &str, project: &str) -> StartProcessRequest {
+        StartProcessRequest {
+            name: name.to_string(),
+            args: vec!["sleep".to_string(), "30".to_string()],
+            project: project.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub async fn start(&self, name: &str, project: &str) -> Result<ProcessInfo, Status> {
+        self.start_with_request(Self::start_request(name, project))
+            .await
+    }
+
+    pub async fn start_with_request(
+        &self,
+        request: StartProcessRequest,
+    ) -> Result<ProcessInfo, Status> {
+        let response = self
+            .service
+            .start_process_impl(Request::new(request))
+            .await?;
+        process_from_start_stream(response.into_inner()).await
+    }
+
+    pub async fn cleanup(mut self) {
+        let processes = self.service.process_manager.get_all_processes();
+        for process in processes {
+            let stop = self.service.process_manager.stop_process(
+                &process.id,
+                Some(&process.project),
+                true,
+            );
+            tokio::time::timeout(Duration::from_secs(15), stop)
+                .await
+                .expect("managed process stop exceeded cleanup deadline")
+                .expect("managed process cleanup failed");
+        }
+        std::fs::remove_dir_all(&self.root).unwrap();
+        self.root = PathBuf::new();
+    }
+}
+
+impl Drop for TestHarness {
+    fn drop(&mut self) {
+        if self.root.as_os_str().is_empty() {
+            return;
+        }
+
+        #[cfg(unix)]
+        for process in self.service.process_manager.get_all_processes() {
+            unsafe {
+                libc::kill(-(process.pid as i32), libc::SIGKILL);
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+pub(super) async fn process_from_start_stream(
+    mut stream: <GrpcService as proto::process_manager_server::ProcessManager>::StartProcessStream,
+) -> Result<ProcessInfo, Status> {
+    while let Some(response) = stream.next().await {
+        let StartProcessResponse { response } = response?;
+        if let Some(start_process_response::Response::Process(process)) = response {
+            return Ok(process);
+        }
+    }
+    Err(Status::new(
+        Code::Internal,
+        "start stream ended without ProcessInfo",
+    ))
+}
+
+pub(super) async fn process_from_restart_stream(
+    mut stream: <GrpcService as proto::process_manager_server::ProcessManager>::RestartProcessStream,
+) -> Result<ProcessInfo, Status> {
+    while let Some(response) = stream.next().await {
+        let RestartProcessResponse { response } = response?;
+        if let Some(restart_process_response::Response::Process(process)) = response {
+            return Ok(process);
+        }
+    }
+    Err(Status::new(
+        Code::Internal,
+        "restart stream ended without ProcessInfo",
+    ))
+}

--- a/mcproc/src/daemon/api/grpc/test_support.rs
+++ b/mcproc/src/daemon/api/grpc/test_support.rs
@@ -1,51 +1,23 @@
 use super::service::GrpcService;
-use crate::common::config::Config;
-use crate::daemon::log::LogHub;
-use crate::daemon::process::ProcessManager;
-use crate::daemon::stream::StreamEventHub;
+use crate::test_support::ProcessTestFixture;
 use proto::{
     restart_process_response, start_process_response, ProcessInfo, RestartProcessResponse,
     StartProcessRequest, StartProcessResponse,
 };
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio_stream::StreamExt;
 use tonic::{Code, Request, Status};
 
 pub(super) struct TestHarness {
     pub service: GrpcService,
-    root: PathBuf,
+    fixture: ProcessTestFixture,
 }
 
 impl TestHarness {
     pub fn new() -> Self {
-        let root = std::env::temp_dir().join(format!("mcproc-grpc-test-{}", uuid::Uuid::new_v4()));
-        let mut config = Config::default();
-        config.paths.data_dir = root.join("data");
-        config.paths.log_dir = root.join("log");
-        config.paths.socket_path = root.join("runtime/mcprocd.sock");
-        config.paths.pid_file = root.join("runtime/mcprocd.pid");
-        config.paths.daemon_log_file = root.join("state/mcprocd.log");
-        config.process.restart.delay_ms = 0;
-        config.process.restart.process_stop_timeout_ms = 10_000;
+        let fixture = ProcessTestFixture::new("mcproc-grpc-test", 10_000);
+        let service = fixture.grpc_service();
 
-        std::fs::create_dir_all(&config.paths.data_dir).unwrap();
-        std::fs::create_dir_all(&config.paths.log_dir).unwrap();
-        std::fs::create_dir_all(config.paths.socket_path.parent().unwrap()).unwrap();
-        std::fs::create_dir_all(config.paths.daemon_log_file.parent().unwrap()).unwrap();
-
-        let config = Arc::new(config);
-        let event_hub = Arc::new(StreamEventHub::new());
-        let log_hub = Arc::new(LogHub::with_event_hub(config.clone(), event_hub.clone()));
-        let process_manager = Arc::new(ProcessManager::with_event_hub(
-            config.clone(),
-            log_hub.clone(),
-            event_hub.clone(),
-        ));
-        let service = GrpcService::new(process_manager, log_hub, config, event_hub);
-
-        Self { service, root }
+        Self { service, fixture }
     }
 
     pub fn start_request(name: &str, project: &str) -> StartProcessRequest {
@@ -74,37 +46,8 @@ impl TestHarness {
     }
 
     pub async fn cleanup(mut self) {
-        let processes = self.service.process_manager.get_all_processes();
-        for process in processes {
-            let stop = self.service.process_manager.stop_process(
-                &process.id,
-                Some(&process.project),
-                true,
-            );
-            tokio::time::timeout(Duration::from_secs(15), stop)
-                .await
-                .expect("managed process stop exceeded cleanup deadline")
-                .expect("managed process cleanup failed");
-        }
-        std::fs::remove_dir_all(&self.root).unwrap();
-        self.root = PathBuf::new();
-    }
-}
-
-impl Drop for TestHarness {
-    fn drop(&mut self) {
-        if self.root.as_os_str().is_empty() {
-            return;
-        }
-
-        #[cfg(unix)]
-        for process in self.service.process_manager.get_all_processes() {
-            unsafe {
-                libc::kill(-(process.pid as i32), libc::SIGKILL);
-            }
-        }
-
-        let _ = std::fs::remove_dir_all(&self.root);
+        self.fixture.stop_all().await;
+        self.fixture.remove_root();
     }
 }
 

--- a/mcproc/src/daemon/process/manager.rs
+++ b/mcproc/src/daemon/process/manager.rs
@@ -885,23 +885,10 @@ impl ProcessManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::daemon::stream::StreamEventHub;
-    use uuid::Uuid;
+    use crate::test_support::ProcessTestFixture;
 
-    fn test_manager() -> (ProcessManager, PathBuf) {
-        let root = std::env::temp_dir().join(format!("mcproc-manager-{}", Uuid::new_v4()));
-        std::fs::create_dir_all(&root).unwrap();
-        let mut config = Config::default();
-        config.paths.data_dir = root.clone();
-        config.paths.log_dir = root.join("logs");
-        config.process.restart.process_stop_timeout_ms = 500;
-        let config = Arc::new(config);
-        let event_hub = Arc::new(StreamEventHub::new());
-        let log_hub = Arc::new(LogHub::with_event_hub(config.clone(), event_hub.clone()));
-        (
-            ProcessManager::with_event_hub(config, log_hub, event_hub),
-            root,
-        )
+    fn test_manager() -> ProcessTestFixture {
+        ProcessTestFixture::new("mcproc-manager", 500)
     }
 
     async fn start_sleep(
@@ -927,9 +914,11 @@ mod tests {
 
     #[tokio::test]
     async fn permits_same_process_name_in_different_projects() {
-        let (manager, root) = test_manager();
-        let first = start_sleep(&manager, "shared-name", "a").await.unwrap();
-        let second = start_sleep(&manager, "shared-name", "b").await.unwrap();
+        let fixture = test_manager();
+        let manager = &fixture.process_manager;
+        let root = fixture.root.clone();
+        let first = start_sleep(manager, "shared-name", "a").await.unwrap();
+        let second = start_sleep(manager, "shared-name", "b").await.unwrap();
         assert_eq!(manager.registry.get_all_processes().len(), 2);
         manager
             .stop_process(&first.id, Some("a"), true)
@@ -945,10 +934,12 @@ mod tests {
     #[tokio::test]
     async fn concurrent_starts_reserve_name_atomically() {
         for _ in 0..10 {
-            let (manager, root) = test_manager();
+            let fixture = test_manager();
+            let manager = &fixture.process_manager;
+            let root = fixture.root.clone();
             let (first, second) = tokio::join!(
-                start_sleep(&manager, "same-name", "same-project"),
-                start_sleep(&manager, "same-name", "same-project")
+                start_sleep(manager, "same-name", "same-project"),
+                start_sleep(manager, "same-name", "same-project")
             );
             assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
             let error = match (first, second) {
@@ -971,7 +962,9 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_log_returns_matching_line_and_running_process() {
-        let (manager, root) = test_manager();
+        let fixture = test_manager();
+        let manager = &fixture.process_manager;
+        let root = fixture.root.clone();
         let result = manager
             .start_process_with_log_stream(
                 "wait-match".to_string(),
@@ -1009,7 +1002,9 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_log_timeout_returns_running_process() {
-        let (manager, root) = test_manager();
+        let fixture = test_manager();
+        let manager = &fixture.process_manager;
+        let root = fixture.root.clone();
         let result = manager
             .start_process_with_log_stream(
                 "wait-timeout".to_string(),
@@ -1047,7 +1042,9 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_log_invalid_regex_releases_process_name() {
-        let (manager, root) = test_manager();
+        let fixture = test_manager();
+        let manager = &fixture.process_manager;
+        let root = fixture.root.clone();
         let invalid_result = manager
             .start_process_with_log_stream(
                 "invalid-wait-pattern".to_string(),
@@ -1074,7 +1071,7 @@ mod tests {
         };
         let registry_was_empty = manager.registry.get_all_processes().is_empty();
 
-        let restart_result = start_sleep(&manager, "invalid-wait-pattern", "wait-for-log").await;
+        let restart_result = start_sleep(manager, "invalid-wait-pattern", "wait-for-log").await;
         let restarted_process = match restart_result {
             Ok(process) => process,
             Err(error) => {

--- a/mcproc/src/daemon/process/manager.rs
+++ b/mcproc/src/daemon/process/manager.rs
@@ -968,4 +968,128 @@ mod tests {
             tokio::fs::remove_dir_all(root).await.unwrap();
         }
     }
+
+    #[tokio::test]
+    async fn wait_for_log_returns_matching_line_and_running_process() {
+        let (manager, root) = test_manager();
+        let result = manager
+            .start_process_with_log_stream(
+                "wait-match".to_string(),
+                Some("wait-for-log".to_string()),
+                Some("echo BOOT; echo READY line; sleep 30".to_string()),
+                Vec::new(),
+                None,
+                None,
+                Some("READY".to_string()),
+                None,
+                None,
+            )
+            .await;
+        let (process, timeout_occurred, pattern_matched, _, matched_line) = match result {
+            Ok(result) => result,
+            Err(error) => {
+                tokio::fs::remove_dir_all(root).await.unwrap();
+                panic!("failed to start process: {error:?}");
+            }
+        };
+        let status = process.get_status();
+
+        let stop_result = manager
+            .stop_process(&process.id, Some("wait-for-log"), true)
+            .await;
+        let remove_result = tokio::fs::remove_dir_all(root).await;
+
+        stop_result.unwrap();
+        remove_result.unwrap();
+        assert!(pattern_matched);
+        assert!(!timeout_occurred);
+        assert!(matched_line.is_some_and(|line| line.contains("READY")));
+        assert_eq!(status, ProcessStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn wait_for_log_timeout_returns_running_process() {
+        let (manager, root) = test_manager();
+        let result = manager
+            .start_process_with_log_stream(
+                "wait-timeout".to_string(),
+                Some("wait-for-log".to_string()),
+                None,
+                vec!["sleep".to_string(), "30".to_string()],
+                None,
+                None,
+                Some("NEVER_APPEARS".to_string()),
+                Some(1),
+                None,
+            )
+            .await;
+        let (process, timeout_occurred, pattern_matched, _, matched_line) = match result {
+            Ok(result) => result,
+            Err(error) => {
+                tokio::fs::remove_dir_all(root).await.unwrap();
+                panic!("failed to start process: {error:?}");
+            }
+        };
+        let status = process.get_status();
+
+        let stop_result = manager
+            .stop_process(&process.id, Some("wait-for-log"), true)
+            .await;
+        let remove_result = tokio::fs::remove_dir_all(root).await;
+
+        stop_result.unwrap();
+        remove_result.unwrap();
+        assert!(timeout_occurred);
+        assert!(!pattern_matched);
+        assert!(matched_line.is_none());
+        assert_eq!(status, ProcessStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn wait_for_log_invalid_regex_releases_process_name() {
+        let (manager, root) = test_manager();
+        let invalid_result = manager
+            .start_process_with_log_stream(
+                "invalid-wait-pattern".to_string(),
+                Some("wait-for-log".to_string()),
+                None,
+                vec!["sleep".to_string(), "30".to_string()],
+                None,
+                None,
+                Some("[unclosed".to_string()),
+                None,
+                None,
+            )
+            .await;
+        let invalid_error = match invalid_result {
+            Err(error) => error,
+            Ok((process, _, _, _, _)) => {
+                manager
+                    .stop_process(&process.id, Some("wait-for-log"), true)
+                    .await
+                    .unwrap();
+                tokio::fs::remove_dir_all(root).await.unwrap();
+                panic!("invalid regex unexpectedly started a process");
+            }
+        };
+        let registry_was_empty = manager.registry.get_all_processes().is_empty();
+
+        let restart_result = start_sleep(&manager, "invalid-wait-pattern", "wait-for-log").await;
+        let restarted_process = match restart_result {
+            Ok(process) => process,
+            Err(error) => {
+                tokio::fs::remove_dir_all(root).await.unwrap();
+                panic!("process name reservation was not released: {error:?}");
+            }
+        };
+        let stop_result = manager
+            .stop_process(&restarted_process.id, Some("wait-for-log"), true)
+            .await;
+        let remove_result = tokio::fs::remove_dir_all(root).await;
+
+        stop_result.unwrap();
+        remove_result.unwrap();
+        assert!(matches!(invalid_error, McprocdError::InvalidRegex { .. }));
+        assert!(registry_was_empty);
+    }
 }

--- a/mcproc/src/daemon/stream/mod.rs
+++ b/mcproc/src/daemon/stream/mod.rs
@@ -93,3 +93,75 @@ impl Default for StreamEventHub {
 }
 
 pub type SharedStreamEventHub = Arc<StreamEventHub>;
+
+#[cfg(test)]
+mod tests {
+    use super::StreamFilter;
+
+    #[test]
+    fn added_log_tests_stream_filter_matches_process_table() {
+        struct Case {
+            project_filter: Option<&'static str>,
+            process_names: &'static [&'static str],
+            event_project: &'static str,
+            event_name: &'static str,
+            expected: bool,
+        }
+
+        let cases = [
+            Case {
+                project_filter: Some("alpha"),
+                process_names: &[],
+                event_project: "alpha",
+                event_name: "worker-a",
+                expected: true,
+            },
+            Case {
+                project_filter: Some("alpha"),
+                process_names: &["worker-a", "worker-b"],
+                event_project: "alpha",
+                event_name: "worker-b",
+                expected: true,
+            },
+            Case {
+                project_filter: Some("alpha"),
+                process_names: &["worker-a"],
+                event_project: "alpha",
+                event_name: "worker-b",
+                expected: false,
+            },
+            Case {
+                project_filter: Some("alpha"),
+                process_names: &[],
+                event_project: "beta",
+                event_name: "worker-a",
+                expected: false,
+            },
+            Case {
+                project_filter: Some("alpha"),
+                process_names: &["worker-a"],
+                event_project: "beta",
+                event_name: "worker-a",
+                expected: false,
+            },
+        ];
+
+        for case in cases {
+            let filter = StreamFilter {
+                project: case.project_filter.map(str::to_string),
+                process_names: case.process_names.iter().map(ToString::to_string).collect(),
+                include_events: false,
+            };
+
+            assert_eq!(
+                filter.matches_process(case.event_project, case.event_name),
+                case.expected,
+                "project={:?}, names={:?}, event={}/{}",
+                case.project_filter,
+                case.process_names,
+                case.event_project,
+                case.event_name,
+            );
+        }
+    }
+}

--- a/mcproc/src/lib.rs
+++ b/mcproc/src/lib.rs
@@ -2,3 +2,6 @@ pub mod cli;
 pub mod client;
 pub mod common;
 pub mod daemon;
+
+#[cfg(test)]
+mod test_support;

--- a/mcproc/src/main.rs
+++ b/mcproc/src/main.rs
@@ -17,7 +17,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         daemon::run_daemon().await
     } else {
         // Run in CLI mode
-        cli::run_cli().await
+        match cli::run_cli().await {
+            Err(error)
+                if error
+                    .downcast_ref::<client::DaemonRestartedForUpgrade>()
+                    .is_some() =>
+            {
+                eprintln!("Daemon restarted successfully. Please run your command again.");
+                Ok(())
+            }
+            result => result,
+        }
     }
 }
 

--- a/mcproc/src/main.rs
+++ b/mcproc/src/main.rs
@@ -3,6 +3,9 @@ mod client;
 mod common;
 mod daemon;
 
+#[cfg(test)]
+mod test_support;
+
 fn is_daemon_invocation(args: &[String]) -> bool {
     args.get(1).is_some_and(|arg| arg == "--daemon")
 }

--- a/mcproc/src/test_support.rs
+++ b/mcproc/src/test_support.rs
@@ -1,0 +1,124 @@
+use crate::common::config::Config;
+use crate::daemon::api::grpc::service::GrpcService;
+use crate::daemon::log::LogHub;
+use crate::daemon::process::ProcessManager;
+use crate::daemon::stream::StreamEventHub;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub(crate) struct ProcessTestFixture {
+    config: Arc<Config>,
+    event_hub: Arc<StreamEventHub>,
+    log_hub: Arc<LogHub>,
+    pub process_manager: Arc<ProcessManager>,
+    pub root: PathBuf,
+}
+
+impl ProcessTestFixture {
+    pub fn new(prefix: &str, process_stop_timeout_ms: u64) -> Self {
+        let root = PathBuf::from("/tmp").join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
+        let mut config = Config::default();
+        config.paths.data_dir = root.join("data");
+        config.paths.log_dir = root.join("log");
+        config.paths.socket_path = root.join("runtime/mcprocd.sock");
+        config.paths.pid_file = root.join("runtime/mcprocd.pid");
+        config.paths.daemon_log_file = root.join("state/mcprocd.log");
+        config.process.restart.delay_ms = 0;
+        config.process.restart.process_stop_timeout_ms = process_stop_timeout_ms;
+
+        create_test_directories(&config);
+
+        let config = Arc::new(config);
+        let event_hub = Arc::new(StreamEventHub::new());
+        let log_hub = Arc::new(LogHub::with_event_hub(config.clone(), event_hub.clone()));
+        let process_manager = Arc::new(ProcessManager::with_event_hub(
+            config.clone(),
+            log_hub.clone(),
+            event_hub.clone(),
+        ));
+
+        Self {
+            config,
+            event_hub,
+            log_hub,
+            process_manager,
+            root,
+        }
+    }
+
+    pub fn grpc_service(&self) -> GrpcService {
+        GrpcService::new(
+            self.process_manager.clone(),
+            self.log_hub.clone(),
+            self.config.clone(),
+            self.event_hub.clone(),
+        )
+    }
+
+    pub fn socket_path(&self) -> PathBuf {
+        self.config.paths.socket_path.clone()
+    }
+
+    pub async fn stop_all(&self) {
+        for process in self.process_manager.get_all_processes() {
+            let stop = self
+                .process_manager
+                .stop_process(&process.id, Some(&process.project), true);
+            tokio::time::timeout(Duration::from_secs(15), stop)
+                .await
+                .expect("managed process stop exceeded cleanup deadline")
+                .expect("managed process cleanup failed");
+        }
+    }
+
+    pub fn remove_root(&mut self) {
+        std::fs::remove_dir_all(&self.root).unwrap();
+        self.root = PathBuf::new();
+    }
+}
+
+impl Drop for ProcessTestFixture {
+    fn drop(&mut self) {
+        if self.root.as_os_str().is_empty() {
+            return;
+        }
+
+        kill_process_groups_and_reap(&self.process_manager);
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn create_test_directories(config: &Config) {
+    std::fs::create_dir_all(&config.paths.data_dir).unwrap();
+    std::fs::create_dir_all(&config.paths.log_dir).unwrap();
+    std::fs::create_dir_all(config.paths.socket_path.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(config.paths.daemon_log_file.parent().unwrap()).unwrap();
+}
+
+fn kill_process_groups_and_reap(process_manager: &ProcessManager) {
+    #[cfg(unix)]
+    {
+        let processes = process_manager.get_all_processes();
+        for process in &processes {
+            unsafe {
+                libc::kill(-(process.pid as i32), libc::SIGKILL);
+            }
+        }
+
+        for process in processes {
+            reap_process(process.pid);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn reap_process(pid: u32) {
+    for _ in 0..50 {
+        let result = unsafe { libc::waitpid(pid as i32, std::ptr::null_mut(), libc::WNOHANG) };
+        if result != 0 {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}

--- a/mcproc/tests/process_stop_test.rs
+++ b/mcproc/tests/process_stop_test.rs
@@ -1,287 +1,305 @@
 #![cfg(unix)]
 
-use std::process::Command;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
 use std::time::Duration;
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout, Instant};
+use uuid::Uuid;
+
+const STOP_TIMEOUT: Duration = Duration::from_secs(60);
+const LOG_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+struct TestEnvironment {
+    root: PathBuf,
+}
+
+impl TestEnvironment {
+    fn new() -> Self {
+        let id = Uuid::new_v4().simple().to_string();
+        // Keep this path short because macOS limits Unix socket paths to 104 bytes.
+        let root = PathBuf::from(format!("/tmp/mcpst-{}", &id[..8]));
+        fs::create_dir_all(&root).expect("Failed to create isolated test root");
+        Self { root }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new("mcproc");
+        command
+            .env("XDG_RUNTIME_DIR", &self.root)
+            .env("XDG_STATE_HOME", &self.root)
+            .env("XDG_CONFIG_HOME", self.root.join("config"))
+            .env("XDG_DATA_HOME", self.root.join("data"));
+        command
+    }
+
+    fn process_log_path(&self, project: &str, process: &str) -> PathBuf {
+        self.root
+            .join("mcproc/log")
+            .join(project)
+            .join(format!("{process}.log"))
+    }
+}
+
+impl Drop for TestEnvironment {
+    fn drop(&mut self) {
+        if let Err(error) = self.command().args(["daemon", "stop"]).output() {
+            eprintln!("Failed to stop isolated mcproc daemon: {error}");
+        }
+        if let Err(error) = fs::remove_dir_all(&self.root) {
+            eprintln!(
+                "Failed to remove isolated test root {}: {error}",
+                self.root.display()
+            );
+        }
+    }
+}
+
+fn run(environment: &TestEnvironment, args: &[&str]) -> Output {
+    environment
+        .command()
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("Failed to execute mcproc {}: {error}", args.join(" ")))
+}
+
+async fn run_with_timeout(
+    environment: &TestEnvironment,
+    args: &[&str],
+    duration: Duration,
+) -> Output {
+    let mut command = environment.command();
+    command.args(args);
+    timeout(duration, tokio::process::Command::from(command).output())
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "mcproc {} timed out after {} seconds",
+                args.join(" "),
+                duration.as_secs()
+            )
+        })
+        .unwrap_or_else(|error| panic!("Failed to execute mcproc {}: {error}", args.join(" ")))
+}
+
+fn running_processes(environment: &TestEnvironment) -> String {
+    let output = run(environment, &["ps", "--status", "running"]);
+    assert!(
+        output.status.success(),
+        "Failed to list running processes: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn assert_running(environment: &TestEnvironment, process: &str) {
+    let processes = running_processes(environment);
+    assert!(
+        processes.contains(process),
+        "Process {process} did not appear as Running. Got:\n{processes}"
+    );
+}
+
+fn assert_not_running(environment: &TestEnvironment, process: &str) {
+    let processes = running_processes(environment);
+    assert!(
+        !processes.contains(process),
+        "Process {process} still appeared as Running after stop. Got:\n{processes}"
+    );
+}
+
+async fn wait_for_log(path: &Path, expected: &str) -> String {
+    let deadline = Instant::now() + LOG_WAIT_TIMEOUT;
+    let mut last_content = String::new();
+
+    loop {
+        let last_error = match fs::read_to_string(path) {
+            Ok(content) => {
+                if content.contains(expected) {
+                    return content;
+                }
+                last_content = content;
+                "none".to_string()
+            }
+            Err(error) => error.to_string(),
+        };
+
+        if Instant::now() >= deadline {
+            panic!(
+                "Timed out waiting for {expected:?} in {}. Last error: {}. Last content:\n{}",
+                path.display(),
+                last_error,
+                last_content
+            );
+        }
+
+        sleep(Duration::from_millis(100)).await;
+    }
+}
 
 /// Test that logs emitted during graceful shutdown (after SIGTERM) are captured.
 /// This test verifies the fix for the issue where logs were lost when stop_process
 /// was called because log capture stopped immediately when status changed to Stopping.
-///
-/// Note: This test requires file logging to be enabled in the mcproc configuration
-/// because after a process is stopped, its in-memory ring buffer is cleared.
-/// The test verifies that logs are correctly written to the log file.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "requires mcproc binary to be installed and file logging enabled"]
+#[ignore = "requires mcproc binary to be installed"]
 async fn test_graceful_shutdown_logs_captured() {
-    use std::path::PathBuf;
+    let environment = TestEnvironment::new();
+    let script = "trap 'echo SIGTERM_RECEIVED; echo GRACEFUL_SHUTDOWN_COMPLETE; exit 0' TERM; echo PROCESS_STARTED; while true; do sleep 1; done";
 
-    // Create a script that outputs logs after receiving SIGTERM
-    let script = r#"
-trap 'echo "SIGTERM_RECEIVED"; sleep 0.5; echo "GRACEFUL_SHUTDOWN_COMPLETE"; exit 0' TERM
-echo "PROCESS_STARTED"
-while true; do
-    sleep 0.1
-done
-"#;
-
-    // Start the process
-    let output = Command::new("mcproc")
-        .args([
+    let output = run(
+        &environment,
+        &[
             "start",
             "test-graceful",
             "--cmd",
-            &format!("sh -c '{}'", script.replace('\n', ";")),
+            script,
             "--project",
             "test-graceful-shutdown",
-        ])
-        .output()
-        .expect("Failed to start process");
-
+        ],
+    );
     assert!(
         output.status.success(),
         "Failed to start graceful shutdown test process: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Wait for process to start and output initial log
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    let log_file_path = environment.process_log_path("test-graceful-shutdown", "test-graceful");
+    wait_for_log(&log_file_path, "PROCESS_STARTED").await;
+    assert_running(&environment, "test-graceful");
 
-    // Verify initial log is captured before stopping
-    let logs_before = Command::new("mcproc")
-        .args([
-            "logs",
+    let stop_output = run_with_timeout(
+        &environment,
+        &[
+            "stop",
             "test-graceful",
             "--project",
             "test-graceful-shutdown",
-            "--tail",
-            "10",
-        ])
-        .output()
-        .expect("Failed to get logs before stop");
-
-    let logs_before_str = String::from_utf8_lossy(&logs_before.stdout);
-    assert!(
-        logs_before_str.contains("PROCESS_STARTED"),
-        "Missing PROCESS_STARTED log before stop. Got:\n{}",
-        logs_before_str
-    );
-
-    // Stop the process - this should trigger SIGTERM and graceful shutdown
-    let stop_result = timeout(
-        Duration::from_secs(10),
-        tokio::process::Command::new("mcproc")
-            .args([
-                "stop",
-                "test-graceful",
-                "--project",
-                "test-graceful-shutdown",
-            ])
-            .output(),
+        ],
+        STOP_TIMEOUT,
     )
     .await;
-
-    assert!(stop_result.is_ok(), "Stop command timed out");
-    let stop_output = stop_result
-        .unwrap()
-        .expect("Failed to execute stop command");
     assert!(
         stop_output.status.success(),
         "Failed to stop process: {}",
         String::from_utf8_lossy(&stop_output.stderr)
     );
+    assert_not_running(&environment, "test-graceful");
 
-    // Wait a bit for logs to be flushed to file
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
-    // Read log file directly since the in-memory ring buffer is cleared after process stops
-    let state_dir = std::env::var("XDG_STATE_HOME").unwrap_or_else(|_| {
-        let home = std::env::var("HOME").expect("HOME not set");
-        format!("{}/.local/state", home)
-    });
-    let log_file_path =
-        PathBuf::from(state_dir).join("mcproc/log/test-graceful-shutdown/test-graceful.log");
-
-    let log_content = std::fs::read_to_string(&log_file_path).unwrap_or_else(|e| {
-        panic!(
-            "Failed to read log file at {:?}: {}. File logging may not be enabled.",
-            log_file_path, e
-        )
-    });
-
-    // Verify that all expected logs are present in the log file
+    let log_content = wait_for_log(&log_file_path, "GRACEFUL_SHUTDOWN_COMPLETE").await;
     assert!(
         log_content.contains("PROCESS_STARTED"),
-        "Missing PROCESS_STARTED in log file. Got:\n{}",
-        log_content
+        "Missing PROCESS_STARTED in log file. Got:\n{log_content}"
     );
     assert!(
         log_content.contains("SIGTERM_RECEIVED"),
-        "Missing SIGTERM_RECEIVED in log file - graceful shutdown logs not captured. Got:\n{}",
-        log_content
+        "Missing SIGTERM_RECEIVED in log file - graceful shutdown logs not captured. Got:\n{log_content}"
     );
-    assert!(
-        log_content.contains("GRACEFUL_SHUTDOWN_COMPLETE"),
-        "Missing GRACEFUL_SHUTDOWN_COMPLETE in log file - graceful shutdown logs not captured. Got:\n{}",
-        log_content
-    );
-
-    // Clean up
-    Command::new("mcproc")
-        .args(["clean", "--project", "test-graceful-shutdown", "--force"])
-        .output()
-        .ok();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires mcproc binary to be installed"]
 async fn test_simple_process_stop() {
-    // Start a simple sleep process
-    let output = Command::new("mcproc")
-        .args([
+    let environment = TestEnvironment::new();
+    let output = run(
+        &environment,
+        &[
             "start",
             "test-sleep",
             "--cmd",
             "sleep 30",
             "--project",
             "test-stop",
-        ])
-        .output()
-        .expect("Failed to start process");
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "Failed to start sleep process: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_running(&environment, "test-sleep");
 
-    assert!(output.status.success(), "Failed to start sleep process");
-
-    // Wait a bit
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
-    // Stop the process with timeout
-    let stop_result = timeout(
-        Duration::from_secs(5),
-        tokio::process::Command::new("mcproc")
-            .args(["stop", "test-sleep", "--project", "test-stop"])
-            .output(),
+    let output = run_with_timeout(
+        &environment,
+        &["stop", "test-sleep", "--project", "test-stop"],
+        STOP_TIMEOUT,
     )
     .await;
-
-    assert!(stop_result.is_ok(), "Stop command timed out");
-    let output = stop_result
-        .unwrap()
-        .expect("Failed to execute stop command");
-    assert!(output.status.success(), "Failed to stop process");
-
-    // Clean up
-    Command::new("mcproc")
-        .args(["clean", "--project", "test-stop", "--force"])
-        .output()
-        .ok();
+    assert!(
+        output.status.success(),
+        "Failed to stop sleep process: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_not_running(&environment, "test-sleep");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires mcproc binary to be installed"]
 async fn test_yes_command_stop() {
-    // Start yes command
-    let output = Command::new("mcproc")
-        .args([
+    let environment = TestEnvironment::new();
+    let output = run(
+        &environment,
+        &[
             "start",
             "test-yes",
             "--cmd",
             "yes hello",
             "--project",
             "test-stop",
-        ])
-        .output()
-        .expect("Failed to start process");
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "Failed to start yes process: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_running(&environment, "test-yes");
 
-    assert!(output.status.success(), "Failed to start yes process");
-
-    // Wait a bit for process to generate logs
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
-    // Stop the process with timeout
-    let stop_result = timeout(
-        Duration::from_secs(30),
-        tokio::process::Command::new("mcproc")
-            .args(["stop", "test-yes", "--project", "test-stop"])
-            .output(),
+    let output = run_with_timeout(
+        &environment,
+        &["stop", "test-yes", "--project", "test-stop"],
+        STOP_TIMEOUT,
     )
     .await;
-
-    if stop_result.is_err() {
-        // Force cleanup
-        Command::new("mcproc")
-            .args(["clean", "--project", "test-stop", "--force"])
-            .output()
-            .ok();
-
-        // Kill any remaining yes processes
-        Command::new("sh")
-            .arg("-c")
-            .arg("pkill -f 'yes hello' || true")
-            .output()
-            .ok();
-    }
-
     assert!(
-        stop_result.is_ok(),
-        "Stop command timed out after 30 seconds"
+        output.status.success(),
+        "Failed to stop yes process: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    let output = stop_result
-        .unwrap()
-        .expect("Failed to execute stop command");
-    assert!(output.status.success(), "Failed to stop yes process");
+    assert_not_running(&environment, "test-yes");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires mcproc binary to be installed"]
 async fn test_pipe_command_stop() {
-    // Start pipe command
-    let output = Command::new("mcproc")
-        .args([
+    let environment = TestEnvironment::new();
+    let output = run(
+        &environment,
+        &[
             "start",
             "test-pipe",
             "--cmd",
-            "yes | head -n 1000",
+            "yes | cat > /dev/null",
             "--project",
             "test-stop",
-        ])
-        .output()
-        .expect("Failed to start process");
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "Failed to start pipe process: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_running(&environment, "test-pipe");
 
-    assert!(output.status.success(), "Failed to start pipe process");
-
-    // Wait a bit
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
-    // Stop the process with timeout
-    let stop_result = timeout(
-        Duration::from_secs(30),
-        tokio::process::Command::new("mcproc")
-            .args(["stop", "test-pipe", "--project", "test-stop"])
-            .output(),
+    let output = run_with_timeout(
+        &environment,
+        &["stop", "test-pipe", "--project", "test-stop"],
+        STOP_TIMEOUT,
     )
     .await;
-
-    if stop_result.is_err() {
-        // Force cleanup
-        Command::new("mcproc")
-            .args(["clean", "--project", "test-stop", "--force"])
-            .output()
-            .ok();
-
-        // Kill any remaining processes
-        Command::new("sh")
-            .arg("-c")
-            .arg("pkill -f 'yes' || true")
-            .output()
-            .ok();
-    }
-
     assert!(
-        stop_result.is_ok(),
-        "Stop command timed out after 30 seconds"
+        output.status.success(),
+        "Failed to stop pipe process: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    let output = stop_result
-        .unwrap()
-        .expect("Failed to execute stop command");
-    assert!(output.status.success(), "Failed to stop pipe process");
+    assert_not_running(&environment, "test-pipe");
 }

--- a/mcproc/tests/process_stop_test.rs
+++ b/mcproc/tests/process_stop_test.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use std::process::Command;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -197,20 +199,14 @@ async fn test_yes_command_stop() {
 
     // Stop the process with timeout
     let stop_result = timeout(
-        Duration::from_secs(10),
+        Duration::from_secs(30),
         tokio::process::Command::new("mcproc")
             .args(["stop", "test-yes", "--project", "test-stop"])
             .output(),
     )
     .await;
 
-    // This test is expected to fail with current implementation
-    if let Ok(inner_result) = stop_result {
-        let output = inner_result.expect("Failed to execute stop command");
-        assert!(output.status.success(), "Failed to stop yes process");
-    } else {
-        eprintln!("WARNING: yes command stop timed out (known issue)");
-
+    if stop_result.is_err() {
         // Force cleanup
         Command::new("mcproc")
             .args(["clean", "--project", "test-stop", "--force"])
@@ -224,6 +220,15 @@ async fn test_yes_command_stop() {
             .output()
             .ok();
     }
+
+    assert!(
+        stop_result.is_ok(),
+        "Stop command timed out after 30 seconds"
+    );
+    let output = stop_result
+        .unwrap()
+        .expect("Failed to execute stop command");
+    assert!(output.status.success(), "Failed to stop yes process");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -249,19 +254,14 @@ async fn test_pipe_command_stop() {
 
     // Stop the process with timeout
     let stop_result = timeout(
-        Duration::from_secs(5),
+        Duration::from_secs(30),
         tokio::process::Command::new("mcproc")
             .args(["stop", "test-pipe", "--project", "test-stop"])
             .output(),
     )
     .await;
 
-    if let Ok(inner_result) = stop_result {
-        let output = inner_result.expect("Failed to execute stop command");
-        assert!(output.status.success(), "Failed to stop pipe process");
-    } else {
-        eprintln!("WARNING: pipe command stop timed out");
-
+    if stop_result.is_err() {
         // Force cleanup
         Command::new("mcproc")
             .args(["clean", "--project", "test-stop", "--force"])
@@ -275,4 +275,13 @@ async fn test_pipe_command_stop() {
             .output()
             .ok();
     }
+
+    assert!(
+        stop_result.is_ok(),
+        "Stop command timed out after 30 seconds"
+    );
+    let output = stop_result
+        .unwrap()
+        .expect("Failed to execute stop command");
+    assert!(output.status.success(), "Failed to stop pipe process");
 }


### PR DESCRIPTION
## Summary

Full-codebase test-coverage hardening following the coverage review: **line coverage 40.9% → 68.5%** (functions 44.0% → 71.8%, measured with `cargo llvm-cov --workspace`). Test executions grow from 129 to 232 (mcp-rs 6→18, mcproc lib 61→103, bin 62→104, plus 5 previously-never-run integration tests now green and wired into CI).

Every addition went through a quality pass (four-lens simplify review + an independent full-diff review); the fixes from that pass are in the final commit.

## What is now covered

### mcp-rs protocol dispatch (`protocol.rs` 48% → covered)
initialize response shape, tools/list, tools/call (success / missing params / unknown tool), the Error-variant→JSON-RPC code mapping table, unknown methods, non-empty and mixed batches, standalone notifications, queued log/progress notification payloads.

**Spec fix found by the new tests**: unknown tool in `tools/call` returned `-32601` (Method not found); the MCP 2025-03-26 spec requires `-32602` (Invalid params). Fixed with a dedicated `Error::ToolNotFound` variant so the domain meaning stays in the type system while the wire code is assigned in the mapping layer.

### gRPC handlers (`process_handlers` 23% / `service` 7% / `helpers` 0% → covered)
An in-process harness builds the real `GrpcService` (uuid-scoped temp config, real ProcessManager/LogHub) and calls the `*_impl` handlers directly: start (success / validation errors / duplicate / force-restart / unknown command returning a **Failed ProcessInfo per the MCP design philosophy**), stop, restart, get, list with project/status filters, clean, daemon status, and `create_process_info` field mapping.

### Log RPCs and streaming
get_logs tail (including the registry-less on-disk fallback), tail=0/empty/missing, follow-mode delivery through the event hub with cross-project filtering, include_events on/off; grep context/regex/missing-file/since-until (timezone-independent via Local conversion); StreamFilter matching table.

### wait_for_log end-to-end
Pattern match with matched_line, timeout flag, invalid regex releasing the name reservation.

### MCP tools (all 7 were at 0%)
A harness serves the real GrpcService over a temp Unix socket and drives each tool's `handle()` through a real `DaemonClient` (`from_channel`): schema sanity, start/stop/restart/ps/status behavior, logs/grep content plus **ANSI-stripping regression coverage**. The start tool's published inputSchema now expresses the "cmd or args required" runtime contract via `anyOf`.

### DaemonClient (was 0%, untestable)
Refactored behavior-preservingly: PID-file interpretation, UDS channel construction, and retry are now focused units with tests (missing/garbage/dead/alive PID files, connect success/failure, delayed-bind retry, retry exhaustion). The version-mismatch path no longer calls `std::process::exit(0)` inside the client — it returns a typed `DaemonRestartedForUpgrade` error which `main()` converts to the same message and exit code 0.

### Integration tests: from dormant to CI-enforced
- The 5 `#[ignore]` integration tests had **never run in CI**. A new `Integration tests (installed binary)` job builds mcproc and runs them single-threaded.
- Running them surfaced a dormant bug: the graceful-shutdown test's shell command was built by joining a multiline literal with `; `, producing `sh` syntax errors — it had never actually executed. Rewritten as a valid one-line script with log polling instead of fixed sleeps.
- Tests are now fully **XDG-isolated under short /tmp roots** (SUN_LEN-safe), so they can never touch a developer's real daemon; the global `pkill -f yes` fallback is gone.
- The warn-only stop tests are real assertions now: a long-lived pipeline (`yes | cat`), stop verified via `ps --status running` (stop exits 0 even for missing processes), 60s outer deadline (the implementation's own budget is 45s+10s).

### Shared test fixture
Temp-config construction, the hub/manager stack, stop-all, and process-group reaping are consolidated into one `#[cfg(test)]` fixture used by the manager, gRPC, and MCP harnesses (~110 duplicated lines removed). Directories are created manually so harnesses never touch the real `~/.config`.

## Flakiness discipline

All new tests use uuid-unique temp roots, no fixed-time completion waits (polling with generous deadlines), and group-leader spawns. Each batch was repeated 5× in isolation; the full suite passed under 8-way CPU load.

## Test plan

- [x] `cargo fmt -- --check` / `cargo clippy --all-targets -- -D warnings` / `cargo build --all-targets`
- [x] `cargo test` — mcp-rs 18 / lib 103 / bin 104 / process_group 2 passed, 0 failed
- [x] Ignored integration tests (isolated XDG): 5 passed in ~6s
- [x] Full suite ×2 under 8-way CPU load — 0 failures
- [x] `cargo llvm-cov`: lines 40.89% → 68.47%
