### PR TITLE
release: v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-07-19
+
+### Fixed
+- **Reliable process termination** - Processes are spawned in their own process group and stopped via group signaling (SIGTERM → SIGKILL escalation), so children spawned mid-stop and orphaned grandchildren no longer survive
+- **`daemon stop` delay** - Removed an unconditional 30-second sleep on shutdown; stopping the daemon now completes in under a second when no processes are running
+- **`clean` log deletion** - The clean command now actually deletes project log files and reports accurate deleted counts (previously always reported 0)
+- **Oversized log lines** - Single log lines larger than 1 MiB are force-flushed in ~1 MiB chunks instead of being silently discarded
+- **Logs of stopped processes** - `get_logs` can now read log files of processes that are no longer in the registry, including project-wide log discovery
+- **Real-time MCP notifications** - Progress and log notifications are now delivered while a tool call is still executing instead of after its response
+- **Log integrity** - Log files open in append mode and a newline is inserted before appending after an unclean shutdown, preventing truncation and joined records
+- **Duplicate daemon prevention** - A connectable socket is treated as a running daemon even when the PID file is stale, so `daemon start` cannot spawn a second daemon
+- **Shutdown log draining** - Daemon shutdown flushes and joins the log pipeline before exiting, so final log lines are no longer lost
+- **Same-name processes across projects** - Processes with the same name in different projects are now permitted
+- **Timezone handling** - `--since`/`--until` naive datetimes are interpreted in local time
+- **Grep memory safety** - Search results are capped at 1000 matches so a match-everything pattern cannot exhaust daemon memory
+
+### Changed
+- **Port detection** - Detected ports are refreshed by a periodic background task instead of spawning `lsof`/`pgrep` on every status/list call, and are cleared when a process stops listening
+
+### Security
+- **Shell escaping** - Arguments passed via `args` are POSIX single-quote escaped to prevent shell injection
+- **Path validation** - Process and project names are validated in log paths to prevent path traversal
+- **File permissions** - mcproc-created runtime directories are restricted to 0700 (pre-existing directories are left untouched with a warning)
+
 ## [0.1.4] - 2026-01-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,7 +1577,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-rs"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "mcproc"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["mcp-rs", "mcproc", "proto"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.80.0"
 authors = ["Atsuhito Machida <neptacox@gmail.com>"]


### PR DESCRIPTION
## Summary
Release v0.1.5: version bump + CHANGELOG for all user-facing changes since v0.1.4.

### Highlights
- Reliable process termination via process groups (#38)
- `daemon stop` no longer takes ~30s (#49)
- `clean` actually deletes project logs (#39)
- Oversized log lines force-flushed instead of discarded (#42)
- Logs readable for processes no longer in the registry (#40)
- Real-time MCP notifications during tool calls (#46)
- Port detection moved to periodic sync (#48)
- Security hardening: shell escaping, path validation, 0700 permissions

### Release plan
After merge: tag `v0.1.5` on main → Release workflow builds binaries and publishes the GitHub Release → trigger `publish-homebrew.yml` to update the tap.

### Verification
- Local: `cargo fmt --check` / `clippy --all-targets -D warnings` / `build --all-targets` / `cargo test` all green
- Manual: release binary verified via CLI and MCP stdio (all 7 tools) against an isolated daemon